### PR TITLE
feat: add fixtures, lineups and weather APIs

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -13,3 +13,7 @@
 - Added tiny seed scripts for NRL teams and fixtures with idempotent upserts.
 - Introduced a Prisma client singleton and repository helpers for fixtures, lineups, odds, and ingest runs.
 - Created a basic repository test seeding an in-memory SQLite db.
+
+## Phase 3 notes
+- Implemented fixtures, lineups, and weather API routes with Zod validation and mocked weather data.
+- Added shared API schemas and Supertest-based API tests covering success and validation errors.

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
     "@eslint/js": "^9.32.0",
     "@prisma/client": "^6.13.0",
     "@types/node": "^24.2.0",
+    "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "eslint": "^9.32.0",
+    "nock": "^14.0.9",
     "prisma": "^6.13.0",
+    "supertest": "^7.1.4",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^24.2.0
         version: 24.2.0
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.39.0
         version: 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
@@ -30,9 +33,15 @@ importers:
       eslint:
         specifier: ^9.32.0
         version: 9.32.0(jiti@2.5.1)
+      nock:
+        specifier: ^14.0.9
+        version: 14.0.9
       prisma:
         specifier: ^6.13.0
         version: 6.13.0(typescript@5.9.2)
+      supertest:
+        specifier: ^7.1.4
+        version: 7.1.4
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -270,6 +279,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
 
+  '@mswjs/interceptors@0.39.5':
+    resolution: {integrity: sha512-B9nHSJYtsv79uo7QdkZ/b/WoKm20IkVSmTc/WCKarmDtFwM0dRx2ouEniqwNkzCSLn3fydzKmnMzjtfdOWt3VQ==}
+    engines: {node: '>=18'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -281,6 +298,18 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
   '@prisma/client@6.13.0':
     resolution: {integrity: sha512-8m2+I3dQovkV8CkDMluiwEV1TxV9EXdT6xaCz39O6jYw7mkf5gwfmi+cL4LJsEPwz5tG7sreBwkRpEMJedGYUQ==}
@@ -418,6 +447,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -427,11 +459,20 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
   '@types/node@24.2.0':
     resolution: {integrity: sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
@@ -541,9 +582,15 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -569,6 +616,14 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -600,6 +655,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -609,6 +671,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -637,18 +702,45 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   effect@3.16.12:
     resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
@@ -728,6 +820,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -762,10 +857,29 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -783,12 +897,28 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -822,6 +952,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -852,6 +985,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -875,13 +1011,34 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -901,6 +1058,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  nock@14.0.9:
+    resolution: {integrity: sha512-aVIPgW9WVyb3XPCqfrwETc+hazxzgt8/QvARHAhC6BYHtTsZONUjlXoIB8EGmwqUBkKvOew4yqkGRBmwctdCrw==}
+    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -913,12 +1074,22 @@ packages:
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -986,12 +1157,20 @@ packages:
       typescript:
         optional: true
 
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1040,6 +1219,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1065,12 +1260,23 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  superagent@10.2.3:
+    resolution: {integrity: sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.1.4:
+    resolution: {integrity: sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==}
+    engines: {node: '>=14.18.0'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1231,6 +1437,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1385,6 +1594,17 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
+  '@mswjs/interceptors@0.39.5':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1396,6 +1616,19 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@prisma/client@6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2)':
     optionalDependencies:
@@ -1498,17 +1731,33 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/methods@1.1.4': {}
+
   '@types/node@24.2.0':
     dependencies:
       undici-types: 7.10.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 24.2.0
+      form-data: 4.0.4
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
 
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -1664,7 +1913,11 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -1698,6 +1951,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   chai@5.2.1:
@@ -1729,11 +1992,19 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
   concat-map@0.0.1: {}
 
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
+
+  cookiejar@2.1.4: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1753,16 +2024,44 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   destr@2.0.5: {}
 
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+
   dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   effect@3.16.12:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.8:
     optionalDependencies:
@@ -1890,6 +2189,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -1920,8 +2221,42 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.2.2
+      dezalgo: 1.0.4
+      once: 1.4.0
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   giget@2.0.0:
     dependencies:
@@ -1942,9 +2277,21 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -1969,6 +2316,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-node-process@1.2.0: {}
+
   is-number@7.0.0: {}
 
   isexe@2.0.0: {}
@@ -1988,6 +2337,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2012,12 +2363,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@2.6.0: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -2032,6 +2395,12 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  nock@14.0.9:
+    dependencies:
+      '@mswjs/interceptors': 0.39.5
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
 
   node-fetch-native@1.6.7: {}
 
@@ -2049,7 +2418,13 @@ snapshots:
       pkg-types: 2.2.0
       tinyexec: 1.0.1
 
+  object-inspect@1.13.4: {}
+
   ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2059,6 +2434,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  outvariant@1.4.3: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -2117,9 +2494,15 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  propagate@2.0.1: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
 
@@ -2186,6 +2569,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -2208,11 +2619,34 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  strict-event-emitter@0.5.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  superagent@10.2.3:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.1
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.4
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.0
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.1.4:
+    dependencies:
+      methods: 1.1.2
+      superagent: 10.2.3
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@7.2.0:
     dependencies:
@@ -2360,6 +2794,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/app/api/fixtures/fixtures.api.test.ts
+++ b/src/app/api/fixtures/fixtures.api.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { handlerToServer } from '../../../../tests/apiTestUtils';
+import { FixturesResponseSchema } from '../../../lib/schemas/api';
+import { GET } from './route';
+
+vi.mock('@prisma/client', () => import('../../../../tests/prismaMock'));
+
+let prisma: any;
+let seedTeams: () => Promise<void>;
+let seedFixtures: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../../../lib/db'));
+  ({ seedTeams } = await import('../../../../scripts/seed/teams'));
+  ({ seedFixtures } = await import('../../../../scripts/seed/fixtures'));
+  await seedTeams();
+  await seedFixtures();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('GET /api/fixtures', () => {
+  it('returns fixtures for a round', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/fixtures?round=1');
+    expect(res.status).toBe(200);
+    const parsed = FixturesResponseSchema.parse(res.body);
+    expect(parsed.fixtures.length).toBeGreaterThan(0);
+    expect(parsed.fixtures[0].home_team.name).toBe('Brisbane Broncos');
+  });
+
+  it('returns 400 for invalid round', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/fixtures?round=0');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/fixtures/route.ts
+++ b/src/app/api/fixtures/route.ts
@@ -1,0 +1,44 @@
+import { FixturesQuerySchema, FixturesResponseSchema } from '../../../lib/schemas/api';
+import { getFixturesByRound } from '../../../lib/repos/fixtures';
+
+type FixtureWithTeams = {
+  id: number;
+  season: number | null;
+  round: number | null;
+  kickoffUtc: Date;
+  homeTeam: { id: number; name: string; shortName: string };
+  awayTeam: { id: number; name: string; shortName: string };
+  venue: string | null;
+  status: string | null;
+};
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parse = FixturesQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parse.success) {
+    return new Response('Invalid round', { status: 400 });
+  }
+  const { round } = parse.data;
+  const fixtures = (await getFixturesByRound(round)) as FixtureWithTeams[];
+  const body = FixturesResponseSchema.parse({
+    fixtures: fixtures.map((f) => ({
+      id: String(f.id),
+      season: f.season != null ? String(f.season) : null,
+      round: f.round ?? round,
+      kickoff_utc: f.kickoffUtc.toISOString(),
+      home_team: {
+        id: String(f.homeTeam.id),
+        name: f.homeTeam.name,
+        short_name: f.homeTeam.shortName,
+      },
+      away_team: {
+        id: String(f.awayTeam.id),
+        name: f.awayTeam.name,
+        short_name: f.awayTeam.shortName,
+      },
+      venue: f.venue ?? null,
+      status: (f.status as 'scheduled' | 'live' | 'finished' | null) ?? null,
+    })),
+  });
+  return Response.json(body);
+}

--- a/src/app/api/lineups/lineups.api.test.ts
+++ b/src/app/api/lineups/lineups.api.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { handlerToServer } from '../../../../tests/apiTestUtils';
+import { LineupsResponseSchema } from '../../../lib/schemas/api';
+import { GET } from './route';
+
+vi.mock('@prisma/client', () => import('../../../../tests/prismaMock'));
+
+let prisma: any;
+let seedTeams: () => Promise<void>;
+let seedFixtures: () => Promise<void>;
+
+async function seedLineups(homeConfirmed: boolean, awayConfirmed: boolean) {
+  const { PrismaClient } = await import('@prisma/client');
+  const p = new PrismaClient();
+  const homeData = {
+    fixtureId: 1,
+    teamId: 1,
+    confirmedAt: homeConfirmed ? new Date('2024-03-01T06:00:00Z') : null,
+    startersJson: ['A'],
+    benchJson: [],
+    outsJson: [],
+  } as any;
+  const awayData = {
+    fixtureId: 1,
+    teamId: 2,
+    confirmedAt: awayConfirmed ? new Date('2024-03-01T06:00:00Z') : null,
+    startersJson: ['B'],
+    benchJson: [],
+    outsJson: [],
+  } as any;
+  await p.lineup.upsert({
+    where: { fixtureId_teamId: { fixtureId: homeData.fixtureId, teamId: homeData.teamId } },
+    update: homeData,
+    create: homeData,
+  });
+  await p.lineup.upsert({
+    where: { fixtureId_teamId: { fixtureId: awayData.fixtureId, teamId: awayData.teamId } },
+    update: awayData,
+    create: awayData,
+  });
+  await p.$disconnect();
+}
+
+beforeAll(async () => {
+  ({ prisma } = await import('../../../lib/db'));
+  ({ seedTeams } = await import('../../../../scripts/seed/teams'));
+  ({ seedFixtures } = await import('../../../../scripts/seed/fixtures'));
+  await seedTeams();
+  await seedFixtures();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('GET /api/lineups', () => {
+  it('reports confirmed false if only one lineup confirmed', async () => {
+    await seedLineups(true, false);
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/lineups?fixture_id=1');
+    expect(res.status).toBe(200);
+    const parsed = LineupsResponseSchema.parse(res.body);
+    expect(parsed.confirmed).toBe(false);
+  });
+
+  it('reports confirmed true when both lineups confirmed', async () => {
+    await seedLineups(true, true);
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/lineups?fixture_id=1');
+    expect(res.status).toBe(200);
+    const parsed = LineupsResponseSchema.parse(res.body);
+    expect(parsed.confirmed).toBe(true);
+  });
+
+  it('returns 400 for missing fixture_id', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/lineups');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/lineups/route.ts
+++ b/src/app/api/lineups/route.ts
@@ -1,0 +1,53 @@
+import { LineupsQuerySchema, LineupsResponseSchema } from '../../../lib/schemas/api';
+import { getLineupsByFixture } from '../../../lib/repos/lineups';
+import { getFixtureById } from '../../../lib/repos/fixtures';
+
+type Lineup = {
+  fixtureId: number;
+  teamId: number;
+  confirmedAt: Date | null;
+  startersJson: unknown[] | null;
+  benchJson: unknown[] | null;
+  outsJson: unknown[] | null;
+};
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parse = LineupsQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parse.success) {
+    return new Response('Invalid fixture_id', { status: 400 });
+  }
+  const fixtureIdStr = parse.data.fixture_id;
+  const fixtureId = Number(fixtureIdStr);
+  if (!Number.isInteger(fixtureId) || fixtureId < 1) {
+    return new Response('Invalid fixture_id', { status: 400 });
+  }
+  const fixture = await getFixtureById(fixtureId);
+  if (!fixture) {
+    return new Response('Fixture not found', { status: 404 });
+  }
+  const lineups = (await getLineupsByFixture(fixtureId)) as Lineup[];
+  const homeLineup = lineups.find((l) => l.teamId === fixture.homeTeamId);
+  const awayLineup = lineups.find((l) => l.teamId === fixture.awayTeamId);
+  const home = {
+    team_id: String(fixture.homeTeamId),
+    confirmed_at: homeLineup?.confirmedAt ? homeLineup.confirmedAt.toISOString() : null,
+    starters: (homeLineup?.startersJson as unknown[]) ?? [],
+    bench: (homeLineup?.benchJson as unknown[]) ?? [],
+    outs: (homeLineup?.outsJson as unknown[]) ?? [],
+  };
+  const away = {
+    team_id: String(fixture.awayTeamId),
+    confirmed_at: awayLineup?.confirmedAt ? awayLineup.confirmedAt.toISOString() : null,
+    starters: (awayLineup?.startersJson as unknown[]) ?? [],
+    bench: (awayLineup?.benchJson as unknown[]) ?? [],
+    outs: (awayLineup?.outsJson as unknown[]) ?? [],
+  };
+  const body = LineupsResponseSchema.parse({
+    fixture_id: fixtureIdStr,
+    confirmed: Boolean(home.confirmed_at && away.confirmed_at),
+    home,
+    away,
+  });
+  return Response.json(body);
+}

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,37 @@
+import { WeatherQuerySchema, WeatherResponseSchema } from '../../../lib/schemas/api';
+import { getFixtureById } from '../../../lib/repos/fixtures';
+
+function mockForecast() {
+  const conditions = ['clear', 'cloudy', 'rain', 'windy'] as const;
+  return {
+    condition: conditions[Math.floor(Math.random() * conditions.length)],
+    temp_c: Math.round(10 + Math.random() * 20),
+    wind_kph: Math.round(Math.random() * 40),
+    rain_chance: Math.round(Math.random() * 100),
+  };
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parse = WeatherQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parse.success) {
+    return new Response('Invalid fixture_id', { status: 400 });
+  }
+  const fixtureIdStr = parse.data.fixture_id;
+  const fixtureId = Number(fixtureIdStr);
+  if (!Number.isInteger(fixtureId) || fixtureId < 1) {
+    return new Response('Invalid fixture_id', { status: 400 });
+  }
+  const fixture = await getFixtureById(fixtureId);
+  if (!fixture) {
+    return new Response('Fixture not found', { status: 404 });
+  }
+  const body = WeatherResponseSchema.parse({
+    fixture_id: fixtureIdStr,
+    venue: fixture.venue ?? null,
+    kickoff_utc: fixture.kickoffUtc.toISOString(),
+    forecast: mockForecast(),
+    source: 'mock' as const,
+  });
+  return Response.json(body);
+}

--- a/src/app/api/weather/weather.api.test.ts
+++ b/src/app/api/weather/weather.api.test.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { handlerToServer } from '../../../../tests/apiTestUtils';
+import { WeatherResponseSchema } from '../../../lib/schemas/api';
+import { GET } from './route';
+
+vi.mock('@prisma/client', () => import('../../../../tests/prismaMock'));
+
+let prisma: any;
+let seedTeams: () => Promise<void>;
+let seedFixtures: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../../../lib/db'));
+  ({ seedTeams } = await import('../../../../scripts/seed/teams'));
+  ({ seedFixtures } = await import('../../../../scripts/seed/fixtures'));
+  await seedTeams();
+  await seedFixtures();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('GET /api/weather', () => {
+  it('returns mocked weather for fixture', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/weather?fixture_id=1');
+    expect(res.status).toBe(200);
+    const parsed = WeatherResponseSchema.parse(res.body);
+    expect(parsed.source).toBe('mock');
+    expect(parsed.forecast.rain_chance).toBeGreaterThanOrEqual(0);
+    expect(parsed.forecast.rain_chance).toBeLessThanOrEqual(100);
+  });
+
+  it('returns 400 for missing fixture_id', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/weather');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/lib/schemas/api.ts
+++ b/src/lib/schemas/api.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+// Query schemas
+export const FixturesQuerySchema = z.object({
+  round: z.coerce.number().int().min(1),
+});
+
+export const LineupsQuerySchema = z.object({
+  fixture_id: z.string().min(1),
+});
+
+export const WeatherQuerySchema = z.object({
+  fixture_id: z.string().min(1),
+});
+
+// Response schemas
+export const TeamSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  short_name: z.string(),
+});
+
+export const FixtureSchema = z.object({
+  id: z.string(),
+  season: z.string().nullable(),
+  round: z.number(),
+  kickoff_utc: z.string(),
+  home_team: TeamSchema,
+  away_team: TeamSchema,
+  venue: z.string().nullable(),
+  status: z.enum(['scheduled', 'live', 'finished']).nullable(),
+});
+
+export const FixturesResponseSchema = z.object({
+  fixtures: z.array(FixtureSchema),
+});
+
+export const LineupTeamSchema = z.object({
+  team_id: z.string(),
+  confirmed_at: z.string().nullable(),
+  starters: z.array(z.unknown()),
+  bench: z.array(z.unknown()),
+  outs: z.array(z.unknown()),
+});
+
+export const LineupsResponseSchema = z.object({
+  fixture_id: z.string(),
+  confirmed: z.boolean(),
+  home: LineupTeamSchema,
+  away: LineupTeamSchema,
+});
+
+export const WeatherResponseSchema = z.object({
+  fixture_id: z.string(),
+  venue: z.string().nullable(),
+  kickoff_utc: z.string(),
+  forecast: z.object({
+    condition: z.enum(['clear', 'cloudy', 'rain', 'windy']),
+    temp_c: z.number(),
+    wind_kph: z.number(),
+    rain_chance: z.number().min(0).max(100),
+  }),
+  source: z.literal('mock'),
+});
+
+export type FixturesResponse = z.infer<typeof FixturesResponseSchema>;
+export type LineupsResponse = z.infer<typeof LineupsResponseSchema>;
+export type WeatherResponse = z.infer<typeof WeatherResponseSchema>;

--- a/tests/apiTestUtils.ts
+++ b/tests/apiTestUtils.ts
@@ -1,0 +1,18 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+export function handlerToServer(handler: (req: Request) => Promise<Response>) {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = `http://localhost${req.url}`;
+    const request = new Request(url, {
+      method: req.method,
+      headers: req.headers as Record<string, string>,
+    });
+    const response = await handler(request);
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    const body = Buffer.from(await response.arrayBuffer());
+    res.end(body);
+  });
+}

--- a/tests/prismaMock.ts
+++ b/tests/prismaMock.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const db = {
+  teams: [] as any[],
+  fixtures: [] as any[],
+  lineups: [] as any[],
+  oddsSnapshots: [] as any[],
+  ingestRuns: [] as any[],
+};
+
+let oddsId = 1;
+let ingestId = 1;
+
+export class PrismaClient {
+  team = {
+    upsert: async ({ where, create, update }: any) => {
+      const existing = db.teams.find((t) => t.id === where.id);
+      if (existing) {
+        Object.assign(existing, update);
+        return existing;
+      }
+      db.teams.push(create);
+      return create;
+    },
+  };
+  fixture = {
+    upsert: async ({ where, create, update }: any) => {
+      const existing = db.fixtures.find((f) => f.id === where.id);
+      if (existing) {
+        Object.assign(existing, update);
+        return existing;
+      }
+      db.fixtures.push(create);
+      return create;
+    },
+    findMany: async ({ where, include }: any) => {
+      let res = db.fixtures.filter((f) => f.round === where.round);
+      res = res.sort((a, b) => new Date(a.kickoffUtc).getTime() - new Date(b.kickoffUtc).getTime());
+      if (include?.homeTeam || include?.awayTeam) {
+        res = res.map((f) => ({
+          ...f,
+          homeTeam: db.teams.find((t) => t.id === f.homeTeamId),
+          awayTeam: db.teams.find((t) => t.id === f.awayTeamId),
+        }));
+      }
+      return res;
+    },
+    findUnique: async ({ where, include }: any) => {
+      const f = db.fixtures.find((fi) => fi.id === where.id);
+      if (!f) return null;
+      if (include?.homeTeam || include?.awayTeam) {
+        return {
+          ...f,
+          homeTeam: db.teams.find((t) => t.id === f.homeTeamId),
+          awayTeam: db.teams.find((t) => t.id === f.awayTeamId),
+        };
+      }
+      return f;
+    },
+  };
+  lineup = {
+    upsert: async ({ where, create, update }: any) => {
+      const { fixtureId, teamId } = where.fixtureId_teamId;
+      const existing = db.lineups.find((l) => l.fixtureId === fixtureId && l.teamId === teamId);
+      if (existing) {
+        Object.assign(existing, update);
+        return existing;
+      }
+      db.lineups.push(create);
+      return create;
+    },
+    findMany: async ({ where, include }: any) => {
+      let res = db.lineups.filter((l) => l.fixtureId === where.fixtureId);
+      if (include?.team) {
+        res = res.map((l) => ({ ...l, team: db.teams.find((t) => t.id === l.teamId) }));
+      }
+      return res;
+    },
+  };
+  oddsSnapshot = {
+    findFirst: async ({ where }: any) => {
+      const res = db.oddsSnapshots
+        .filter((o) => o.fixtureId === where.fixtureId)
+        .sort((a, b) => new Date(b.capturedAt).getTime() - new Date(a.capturedAt).getTime());
+      return res[0] ?? null;
+    },
+    update: async ({ where, data }: any) => {
+      const o = db.oddsSnapshots.find((os) => os.id === where.id);
+      if (!o) return null;
+      Object.assign(o, data);
+      return o;
+    },
+    create: async ({ data }: any) => {
+      const obj = { ...data, id: oddsId++ };
+      db.oddsSnapshots.push(obj);
+      return obj;
+    },
+  };
+  ingestRun = {
+    create: async ({ data }: any) => {
+      const run = { id: ingestId++, startedAt: new Date(), ...data };
+      db.ingestRuns.push(run);
+      return run;
+    },
+    findMany: async ({ take }: any) => {
+      return db.ingestRuns
+        .slice()
+        .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())
+        .slice(0, take);
+    },
+  };
+  $disconnect = async () => {};
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,5 @@
+import nock from 'nock';
+
+process.env.NODE_ENV = 'test';
+nock.disableNetConnect();
+nock.enableNetConnect('127.0.0.1');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['**/*.test.ts'],
+    setupFiles: ['./tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- add fixtures, lineups, and weather endpoints with zod validation and mocked forecast
- introduce shared API schemas and test utilities
- cover endpoints with Supertest and seed-based API tests

## Testing
- `pnpm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68962bbe0084832a9fd134894f8ed6cc