### PR TITLE
feat(api): add admin odds CSV upload with validation and upsert

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -17,3 +17,7 @@
 ## Phase 3 notes
 - Implemented fixtures, lineups, and weather API routes with Zod validation and mocked weather data.
 - Added shared API schemas and Supertest-based API tests covering success and validation errors.
+
+## Phase 4 notes
+- Added admin odds CSV upload endpoint with header auth, CSV parsing, zod validation, and upsert logic.
+- Covered upload behavior with Supertest-based API tests for auth, validation errors, and idempotent re-uploads.

--- a/src/app/api/odds/upload/odds-upload.api.test.ts
+++ b/src/app/api/odds/upload/odds-upload.api.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { handlerToServer } from '../../../../../tests/apiTestUtils';
+import { POST } from './route';
+
+vi.mock('@prisma/client', () => import('../../../../../tests/prismaMock'));
+
+let prisma: any;
+let seedTeams: () => Promise<void>;
+let seedFixtures: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../../../../lib/db'));
+  ({ seedTeams } = await import('../../../../../scripts/seed/teams'));
+  ({ seedFixtures } = await import('../../../../../scripts/seed/fixtures'));
+  await seedTeams();
+  await seedFixtures();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('POST /api/odds/upload', () => {
+  const csv = [
+    'fixture_id,captured_at,home_win,away_win,line,total,anytime_tryscorer_json',
+    '1,2024-03-01T09:00:00Z,1.5,2.5,-3.5,40.5,"[{""player_id"":""sr:player:1"",""price"":2.2}]"',
+    '1,2024-03-01T10:00:00Z,1.6,2.4,-4.5,41,"[{""player_id"":""sr:player:2"",""price"":3.5}]"',
+  ].join('\n');
+
+  it('requires auth header', async () => {
+    const server = handlerToServer(POST);
+    const res = await request(server)
+      .post('/api/odds/upload')
+      .attach('file', Buffer.from(csv), 'odds.csv');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when file missing', async () => {
+    const server = handlerToServer(POST);
+    const res = await request(server)
+      .post('/api/odds/upload')
+      .set('x-demo-admin', '1')
+      .field('foo', 'bar');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 on invalid row', async () => {
+    const server = handlerToServer(POST);
+    const badCsv = 'fixture_id,captured_at\n1,not-a-date';
+    const res = await request(server)
+      .post('/api/odds/upload')
+      .set('x-demo-admin', '1')
+      .attach('file', Buffer.from(badCsv), 'odds.csv');
+    expect(res.status).toBe(400);
+    expect(res.text).toContain('Row 2');
+  });
+
+  it('inserts and updates rows', async () => {
+    const server = handlerToServer(POST);
+    let res = await request(server)
+      .post('/api/odds/upload')
+      .set('x-demo-admin', '1')
+      .attach('file', Buffer.from(csv), 'odds.csv');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ inserted: 2, updated: 0, rows: 2 });
+    res = await request(server)
+      .post('/api/odds/upload')
+      .set('x-demo-admin', '1')
+      .attach('file', Buffer.from(csv), 'odds.csv');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ inserted: 0, updated: 2, rows: 2 });
+  });
+});

--- a/src/app/api/odds/upload/route.ts
+++ b/src/app/api/odds/upload/route.ts
@@ -1,0 +1,57 @@
+import { parseCsv } from '../../../../lib/csv';
+import { prisma } from '../../../../lib/db';
+import { zOddsRow, type OddsRow } from '../../../../lib/schemas/odds';
+
+export async function POST(req: Request): Promise<Response> {
+  if (req.headers.get('x-demo-admin') !== '1') {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return new Response('Invalid multipart', { status: 400 });
+  }
+  const file = form.get('file');
+  if (!(file instanceof File)) {
+    return new Response('Missing file', { status: 400 });
+  }
+  const text = await file.text();
+  const records = parseCsv(text);
+  const valid: OddsRow[] = [];
+  const errors: { row: number; message: string }[] = [];
+  records.forEach((record, idx) => {
+    const res = zOddsRow.safeParse(record);
+    if (res.success) {
+      valid.push(res.data);
+    } else {
+      errors.push({ row: idx + 2, message: res.error.issues[0].message });
+    }
+  });
+  if (errors.length) {
+    const msg = errors
+      .slice(0, 3)
+      .map((e) => `Row ${e.row}: ${e.message}`)
+      .join('; ');
+    return new Response(msg, { status: 400 });
+  }
+  let inserted = 0;
+  let updated = 0;
+  for (const row of valid) {
+    const existing = await prisma.oddsSnapshot.findFirst({
+      where: { fixtureId: row.fixtureId, capturedAt: row.capturedAt },
+    });
+    if (existing) {
+      await prisma.oddsSnapshot.update({
+        where: { id: existing.id },
+        data: row,
+      });
+      updated += 1;
+    } else {
+      await prisma.oddsSnapshot.create({ data: row });
+      inserted += 1;
+    }
+  }
+  return Response.json({ inserted, updated, rows: valid.length });
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,47 @@
+/**
+ * Minimal CSV parser supporting quoted fields.
+ * Returns array of records keyed by header names.
+ */
+export function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const headers = parseLine(lines[0]);
+  const rows: Record<string, string>[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const values = parseLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      if (values[idx] !== undefined) {
+        row[h] = values[idx];
+      }
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+}

--- a/src/lib/schemas/odds.ts
+++ b/src/lib/schemas/odds.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+const AnytimeTryscorerSchema = z.array(
+  z.object({ player_id: z.string(), price: z.number() })
+);
+
+/**
+ * Parses the anytime_tryscorer_json field into a typed array.
+ */
+export function parseAnytimeTryscorerJson(
+  value: string | undefined,
+  ctx?: z.RefinementCtx
+) {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return AnytimeTryscorerSchema.parse(parsed);
+  } catch {
+    if (ctx) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Invalid anytime_tryscorer_json',
+      });
+      return z.NEVER;
+    }
+    throw new Error('Invalid anytime_tryscorer_json');
+  }
+}
+
+export const zOddsRow = z
+  .object({
+    fixture_id: z.string().min(1),
+    captured_at: z
+      .string()
+      .refine((v) => !Number.isNaN(Date.parse(v)), 'Invalid captured_at')
+      .transform((v) => new Date(v)),
+    home_win: z.coerce.number().optional(),
+    away_win: z.coerce.number().optional(),
+    line: z.coerce.number().optional(),
+    total: z.coerce.number().optional(),
+    anytime_tryscorer_json: z
+      .string()
+      .optional()
+      .transform((v, ctx) => parseAnytimeTryscorerJson(v, ctx)),
+  })
+  .passthrough()
+  .transform((row) => ({
+    fixtureId: parseInt(row.fixture_id, 10),
+    capturedAt: row.captured_at,
+    homeWin: row.home_win,
+    awayWin: row.away_win,
+    line: row.line,
+    total: row.total,
+    anytimeTryscorerJson: row.anytime_tryscorer_json,
+  }));
+
+export type OddsRow = z.infer<typeof zOddsRow>;

--- a/tests/apiTestUtils.ts
+++ b/tests/apiTestUtils.ts
@@ -3,16 +3,22 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 export function handlerToServer(handler: (req: Request) => Promise<Response>) {
   return createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const url = `http://localhost${req.url}`;
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    }
+    const body = Buffer.concat(chunks);
     const request = new Request(url, {
       method: req.method,
       headers: req.headers as Record<string, string>,
+      body: body.length > 0 ? body : undefined,
     });
     const response = await handler(request);
     res.statusCode = response.status;
     response.headers.forEach((value, key) => {
       res.setHeader(key, value);
     });
-    const body = Buffer.from(await response.arrayBuffer());
-    res.end(body);
+    const respBody = Buffer.from(await response.arrayBuffer());
+    res.end(respBody);
   });
 }

--- a/tests/prismaMock.ts
+++ b/tests/prismaMock.ts
@@ -78,9 +78,12 @@ export class PrismaClient {
   };
   oddsSnapshot = {
     findFirst: async ({ where }: any) => {
-      const res = db.oddsSnapshots
-        .filter((o) => o.fixtureId === where.fixtureId)
-        .sort((a, b) => new Date(b.capturedAt).getTime() - new Date(a.capturedAt).getTime());
+      let res = db.oddsSnapshots.filter((o) => o.fixtureId === where.fixtureId);
+      if (where.capturedAt) {
+        const t = new Date(where.capturedAt).getTime();
+        res = res.filter((o) => new Date(o.capturedAt).getTime() === t);
+      }
+      res = res.sort((a, b) => new Date(b.capturedAt).getTime() - new Date(a.capturedAt).getTime());
       return res[0] ?? null;
     },
     update: async ({ where, data }: any) => {


### PR DESCRIPTION
## Summary
- add secure `/api/odds/upload` endpoint that parses odds snapshots from CSV and upserts into DB
- provide zod schemas and CSV helper for typed validation
- cover upload behavior with Supertest tests and document in build notes

## Testing
- `pnpm run ci`


------
https://chatgpt.com/codex/tasks/task_e_689636e69794832a9ecc3aee0ec99d6b