### PR TITLE
feat: add rule-based tip engine and tips API

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -21,3 +21,8 @@
 ## Phase 4 notes
 - Added admin odds CSV upload endpoint with header auth, CSV parsing, zod validation, and upsert logic.
 - Covered upload behavior with Supertest-based API tests for auth, validation errors, and idempotent re-uploads.
+
+## Phase 5 notes
+- Implemented deterministic rule-based tip engine with seeded RNG, risk bands, and weather adjustments.
+- Exposed `/api/tips` with zod query validation returning composed legs and confidence scores.
+- Added unit and API tests for tip engine determinism, weather effects, exclusions, and confidence bounds.

--- a/src/app/api/tips/route.ts
+++ b/src/app/api/tips/route.ts
@@ -1,0 +1,23 @@
+import { TipsQuerySchema, TipsResponseSchema } from '../../../lib/schemas/api';
+import { buildTips } from '../../../features/tips/engine';
+import { RiskBand, Market } from '../../../features/tips/constants';
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parse = TipsQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parse.success) {
+    return new Response('Invalid params', { status: 400 });
+  }
+  const { fixture_id, risk = 'balanced', exclude, seed = 'mvp' } = parse.data;
+  const excludeArr = exclude
+    ? (exclude.split(',').filter(Boolean) as Market[])
+    : [];
+  const body = await buildTips({
+    fixtureId: Number(fixture_id),
+    risk: risk as RiskBand,
+    exclude: excludeArr,
+    seed,
+  });
+  const validated = TipsResponseSchema.parse(body);
+  return Response.json(validated);
+}

--- a/src/app/api/tips/tips.api.test.ts
+++ b/src/app/api/tips/tips.api.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import { handlerToServer } from '../../../../tests/apiTestUtils';
+import { TipsResponseSchema } from '../../../lib/schemas/api';
+import { GET } from './route';
+const fixture = {
+  id: 1,
+  homeTeam: { id: 1, name: 'Home', shortName: 'HOM' },
+  awayTeam: { id: 2, name: 'Away', shortName: 'AWY' },
+};
+
+const lineups = [
+  {
+    fixtureId: 1,
+    teamId: 1,
+    confirmedAt: new Date(),
+    startersJson: [
+      { id: 1, name: 'P1', position: 'Wing', stats: { tries: 3 } },
+      { id: 2, name: 'P2', position: 'Centre', stats: { tries: 2 } },
+      { id: 3, name: 'P3', position: 'Halfback', stats: { tries: 1 } },
+    ],
+    benchJson: [],
+    outsJson: [],
+  },
+  {
+    fixtureId: 1,
+    teamId: 2,
+    confirmedAt: new Date(),
+    startersJson: [
+      { id: 4, name: 'P4', position: 'Wing', stats: { tries: 2 } },
+      { id: 5, name: 'P5', position: 'Fullback', stats: { tries: 1 } },
+      { id: 6, name: 'P6', position: 'Lock', stats: { tries: 0 } },
+    ],
+    benchJson: [],
+    outsJson: [],
+  },
+];
+
+vi.mock('../../../lib/repos/fixtures', () => ({
+  getFixtureById: async () => fixture,
+}));
+
+vi.mock('../../../lib/repos/lineups', () => ({
+  getLineupsByFixture: async () => lineups,
+}));
+
+vi.mock('../../../lib/repos/odds', () => ({
+  getLatestOddsSnapshot: async () => null,
+}));
+
+describe('GET /api/tips', () => {
+  it('400 on bad params', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/tips');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns >=6 legs for balanced default', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/tips?fixture_id=1');
+    expect(res.status).toBe(200);
+    const body = TipsResponseSchema.parse(res.body);
+    expect(body.legs.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('spicy returns >=7 legs', async () => {
+    const server = handlerToServer(GET);
+    const res = await request(server).get('/api/tips?fixture_id=1&risk=spicy');
+    expect(res.status).toBe(200);
+    const body = TipsResponseSchema.parse(res.body);
+    expect(body.legs.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('deterministic with seed', async () => {
+    const server = handlerToServer(GET);
+    const r1 = await request(server).get('/api/tips?fixture_id=1&seed=unit');
+    const r2 = await request(server).get('/api/tips?fixture_id=1&seed=unit');
+    expect(r1.body).toEqual(r2.body);
+  });
+});

--- a/src/features/tips/__tests__/engine.test.ts
+++ b/src/features/tips/__tests__/engine.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildTips } from '../engine';
+import { Market, RiskBand, CONFIDENCE_CLAMPS } from '../constants';
+
+const fixture = {
+  id: 1,
+  homeTeam: { id: 1, name: 'Home', shortName: 'HOM' },
+  awayTeam: { id: 2, name: 'Away', shortName: 'AWY' },
+};
+
+const lineups = [
+  {
+    fixtureId: 1,
+    teamId: 1,
+    confirmedAt: new Date(),
+    startersJson: [
+      { id: 1, name: 'P1', position: 'Wing', stats: { tries: 3 } },
+      { id: 2, name: 'P2', position: 'Centre', stats: { tries: 2 } },
+      { id: 3, name: 'P3', position: 'Halfback', stats: { tries: 1 } },
+    ],
+    benchJson: [],
+    outsJson: [],
+  },
+  {
+    fixtureId: 1,
+    teamId: 2,
+    confirmedAt: new Date(),
+    startersJson: [
+      { id: 4, name: 'P4', position: 'Wing', stats: { tries: 2 } },
+      { id: 5, name: 'P5', position: 'Fullback', stats: { tries: 1 } },
+      { id: 6, name: 'P6', position: 'Lock', stats: { tries: 0 } },
+    ],
+    benchJson: [],
+    outsJson: [],
+  },
+];
+
+vi.mock('../../../lib/repos/fixtures', () => ({
+  getFixtureById: async () => fixture,
+}));
+
+vi.mock('../../../lib/repos/lineups', () => ({
+  getLineupsByFixture: async () => lineups,
+}));
+
+vi.mock('../../../lib/repos/odds', () => ({
+  getLatestOddsSnapshot: async () => null,
+}));
+
+describe('tip engine', () => {
+  it('is deterministic given seed', async () => {
+    const a = await buildTips({ fixtureId: 1, risk: RiskBand.Balanced, seed: 'unit' });
+    const b = await buildTips({ fixtureId: 1, risk: RiskBand.Balanced, seed: 'unit' });
+    expect(a).toEqual(b);
+  });
+
+  it('weather rain reduces tryscorer confidence and boosts unders', async () => {
+    const dry = await buildTips({ fixtureId: 1, risk: RiskBand.Balanced, seed: 'clear' });
+    const wet = await buildTips({ fixtureId: 1, risk: RiskBand.Balanced, seed: 'rain' });
+    const dryTry = dry.legs.find((l) => l.market === Market.AnytimeTryscorer)!;
+    const wetTry = wet.legs.find((l) => l.market === Market.AnytimeTryscorer)!;
+    expect(wetTry.confidence).toBeLessThan(dryTry.confidence);
+    const wetTotal = wet.legs.find((l) => l.market === Market.TotalPoints)!;
+    expect(wetTotal.selection.startsWith('Under')).toBe(true);
+  });
+
+  it('respects exclude parameter', async () => {
+    const res = await buildTips({
+      fixtureId: 1,
+      risk: RiskBand.Balanced,
+      seed: 'unit',
+      exclude: [Market.AnytimeTryscorer],
+    });
+    expect(res.legs.some((l) => l.market === Market.AnytimeTryscorer)).toBe(false);
+  });
+
+  it('clamps confidence per risk band', async () => {
+    for (const risk of [RiskBand.Safe, RiskBand.Balanced, RiskBand.Spicy] as const) {
+      const res = await buildTips({ fixtureId: 1, risk, seed: 'bounds' });
+      const { min, max } = CONFIDENCE_CLAMPS[risk];
+      res.legs.forEach((l) => {
+        expect(l.confidence).toBeGreaterThanOrEqual(min);
+        expect(l.confidence).toBeLessThanOrEqual(max);
+      });
+    }
+  });
+});

--- a/src/features/tips/constants.ts
+++ b/src/features/tips/constants.ts
@@ -1,0 +1,53 @@
+export enum RiskBand {
+  Safe = 'safe',
+  Balanced = 'balanced',
+  Spicy = 'spicy',
+}
+
+export enum Market {
+  MatchLine = 'match_line',
+  TotalPoints = 'total_points',
+  AnytimeTryscorer = 'anytime_tryscorer',
+  FirstHalfResult = 'first_half_result',
+  AltTotalPoints = 'alt_total_points',
+  FirstTryscorer = 'first_tryscorer',
+}
+
+export const PRICE_RANGES: Record<Market, { min: number; max: number }> = {
+  [Market.MatchLine]: { min: 1.8, max: 2.1 },
+  [Market.TotalPoints]: { min: 1.8, max: 2.1 },
+  [Market.AnytimeTryscorer]: { min: 1.9, max: 4.5 },
+  [Market.FirstHalfResult]: { min: 1.8, max: 2.5 },
+  [Market.AltTotalPoints]: { min: 2.0, max: 3.0 },
+  [Market.FirstTryscorer]: { min: 8.0, max: 18.0 },
+};
+
+export const CONFIDENCE_CLAMPS: Record<RiskBand, { min: number; max: number }> = {
+  [RiskBand.Safe]: { min: 0.7, max: 0.92 },
+  [RiskBand.Balanced]: { min: 0.6, max: 0.9 },
+  [RiskBand.Spicy]: { min: 0.5, max: 0.85 },
+};
+
+export const RISK_RULES = {
+  [RiskBand.Safe]: {
+    targetLegs: 4,
+    maxTryscorers: 1,
+    tryscorerPriceCap: 2.5,
+  },
+  [RiskBand.Balanced]: {
+    targetLegs: 6,
+    maxTryscorers: 2,
+    tryscorerPriceCap: 3.5,
+  },
+  [RiskBand.Spicy]: {
+    targetLegs: 8,
+    maxTryscorers: 4,
+    tryscorerPriceCap: 4.5,
+  },
+} as const;
+
+export function clampConfidence(value: number, risk: RiskBand): number {
+  const { min, max } = CONFIDENCE_CLAMPS[risk];
+  const v = Math.min(Math.max(value, min), max);
+  return Math.round(v * 100) / 100;
+}

--- a/src/features/tips/engine.ts
+++ b/src/features/tips/engine.ts
@@ -1,0 +1,204 @@
+import { getFixtureById } from '../../lib/repos/fixtures';
+import { getLineupsByFixture } from '../../lib/repos/lineups';
+import { getLatestOddsSnapshot } from '../../lib/repos/odds';
+import { RiskBand, Market, RISK_RULES, PRICE_RANGES, clampConfidence } from './constants';
+import { createRng } from './seededRng';
+
+export interface TipLeg {
+  market: Market;
+  selection: string;
+  price: number;
+  confidence: number;
+  rationale: string;
+}
+
+export interface BuildTipsArgs {
+  fixtureId: number | string;
+  risk: RiskBand;
+  exclude?: Market[];
+  seed?: string;
+}
+
+export interface TipsResult {
+  fixture_id: string;
+  risk: RiskBand;
+  legs: TipLeg[];
+}
+
+type Weather = {
+  condition: 'clear' | 'cloudy' | 'rain' | 'windy';
+  temp_c: number;
+  wind_kph: number;
+  rain_chance: number;
+};
+
+function mockWeather(seed: string, fixtureId: number): Weather {
+  const rng = createRng(`${seed}-${fixtureId}-weather`);
+  const conditions: Weather['condition'][] = ['clear', 'cloudy', 'rain', 'windy'];
+  const condition = conditions[Math.floor(rng() * conditions.length)];
+  return {
+    condition,
+    temp_c: Math.round(10 + rng() * 20),
+    wind_kph: Math.round(rng() * 40),
+    rain_chance: Math.round(rng() * 100),
+  };
+}
+
+function randomPrice(m: Market, rng: () => number): number {
+  const band = PRICE_RANGES[m];
+  const p = band.min + rng() * (band.max - band.min);
+  return Math.round(p * 100) / 100;
+}
+
+function playerFormScore(p: any): number {
+  const tries = p.stats?.tries ?? 0;
+  if (tries) return Math.min(tries / 5, 1);
+  const pos = String(p.position || '').toLowerCase();
+  if (pos.includes('wing')) return 0.6;
+  if (pos.includes('full')) return 0.55;
+  if (pos.includes('centre')) return 0.5;
+  if (pos.includes('half')) return 0.45;
+  return 0.3;
+}
+
+function matchupScore(): number {
+  return 0.1; // simple placeholder edge advantage
+}
+
+function weatherTryAdjust(w: Weather): number {
+  return w.condition === 'rain' || w.condition === 'windy' ? -0.1 : 0;
+}
+
+function weatherTotalAdjust(w: Weather, pick: 'under' | 'over'): number {
+  if (w.condition === 'rain' || w.condition === 'windy') {
+    return pick === 'under' ? 0.05 : -0.05;
+  }
+  return 0;
+}
+
+export async function buildTips({
+  fixtureId,
+  risk,
+  exclude = [],
+  seed = 'mvp',
+}: BuildTipsArgs): Promise<TipsResult> {
+  const id = typeof fixtureId === 'string' ? Number(fixtureId) : fixtureId;
+  const rng = createRng(seed);
+  const fixture = await getFixtureById(id);
+  if (!fixture) {
+    return { fixture_id: String(fixtureId), risk, legs: [] };
+  }
+  const lineups = await getLineupsByFixture(id);
+  const odds = await getLatestOddsSnapshot(id); // optional, may be null
+  const weather = mockWeather(seed, id);
+  const confirmed = lineups.every((l) => l.confirmedAt);
+
+  const rules = RISK_RULES[risk];
+  const legs: TipLeg[] = [];
+
+  // Match line
+  if (!exclude.includes(Market.MatchLine)) {
+    const line = odds?.line ?? 6.5;
+    const sel = `${fixture.homeTeam.shortName ?? 'Home'} ${line >= 0 ? '-' : '+'}${Math.abs(line)}`;
+    const conf = clampConfidence(0.75 + rng() * 0.05, risk);
+    legs.push({
+      market: Market.MatchLine,
+      selection: sel,
+      price: randomPrice(Market.MatchLine, rng),
+      confidence: conf,
+      rationale: 'Home form + travel disadvantage',
+    });
+  }
+
+  // Total points
+  if (!exclude.includes(Market.TotalPoints)) {
+    const total = odds?.total ?? 42.5;
+    const pick = weather.condition === 'rain' || weather.condition === 'windy' ? 'Under' : 'Over';
+    const conf = clampConfidence(0.7 + weatherTotalAdjust(weather, pick.toLowerCase() as any), risk);
+    legs.push({
+      market: Market.TotalPoints,
+      selection: `${pick} ${total}`,
+      price: randomPrice(Market.TotalPoints, rng),
+      confidence: conf,
+      rationale: `${weather.condition} forecast favors ${pick.toLowerCase()}`,
+    });
+  }
+
+  // Alt total for balanced/spicy
+  if (risk !== RiskBand.Safe && !exclude.includes(Market.AltTotalPoints)) {
+    const total = (odds?.total ?? 42.5) + (risk === RiskBand.Spicy ? 6 : 4);
+    const pick = weather.condition === 'rain' || weather.condition === 'windy' ? 'Under' : 'Over';
+    const conf = clampConfidence(0.62 + weatherTotalAdjust(weather, pick.toLowerCase() as any), risk);
+    legs.push({
+      market: Market.AltTotalPoints,
+      selection: `${pick} ${total}`,
+      price: randomPrice(Market.AltTotalPoints, rng),
+      confidence: conf,
+      rationale: `Alt total adjusted for ${weather.condition}`,
+    });
+  }
+
+  // First half result
+  if (!exclude.includes(Market.FirstHalfResult)) {
+    const pick = rng() > 0.5 ? fixture.homeTeam.shortName ?? 'Home' : fixture.awayTeam.shortName ?? 'Away';
+    const conf = clampConfidence(0.68 + rng() * 0.04, risk);
+    legs.push({
+      market: Market.FirstHalfResult,
+      selection: `${pick} HT`,
+      price: randomPrice(Market.FirstHalfResult, rng),
+      confidence: conf,
+      rationale: 'Momentum in opening stanza',
+    });
+  }
+
+  // Any time tryscorers
+  if (!exclude.includes(Market.AnytimeTryscorer)) {
+    const starters = lineups.flatMap((l) => (Array.isArray(l.startersJson) ? l.startersJson : []));
+    const outs = new Set(
+      lineups.flatMap((l) => (Array.isArray(l.outsJson) ? l.outsJson : [])).map((p: any) => p.id),
+    );
+    const candidates = starters.filter((p: any) => !outs.has(p.id));
+    // shuffle deterministically
+    candidates.sort((a: any, b: any) => (createRng(`${seed}-${a.id}`)() - createRng(`${seed}-${b.id}`)()));
+    let added = 0;
+    for (const p of candidates) {
+      if (added >= rules.maxTryscorers) break;
+      if (!confirmed && risk !== RiskBand.Spicy) break;
+      const form = playerFormScore(p);
+      const base = 0.55 + form * 0.2 + matchupScore();
+      const conf = clampConfidence(base + weatherTryAdjust(weather), risk);
+      let price = randomPrice(Market.AnytimeTryscorer, rng);
+      if (p.position && String(p.position).toLowerCase().includes('wing')) {
+        price = Math.max(price - 0.5, PRICE_RANGES[Market.AnytimeTryscorer].min);
+      }
+      price = Math.min(price, rules.tryscorerPriceCap);
+      legs.push({
+        market: Market.AnytimeTryscorer,
+        selection: p.name,
+        price,
+        confidence: conf,
+        rationale: `Recent form + matchup edge`,
+      });
+      added += 1;
+    }
+  }
+
+  // Ensure we have at least target legs by duplicating totals if needed
+  if (legs.length < rules.targetLegs && !exclude.includes(Market.TotalPoints)) {
+    while (legs.length < rules.targetLegs) {
+      const total = (odds?.total ?? 42.5) + Math.round(rng() * 10 - 5);
+      const pick = rng() > 0.5 ? 'Over' : 'Under';
+      const conf = clampConfidence(0.6 + weatherTotalAdjust(weather, pick.toLowerCase() as any), risk);
+      legs.push({
+        market: Market.TotalPoints,
+        selection: `${pick} ${total}`,
+        price: randomPrice(Market.TotalPoints, rng),
+        confidence: conf,
+        rationale: 'Alt view on total',
+      });
+    }
+  }
+
+  legs.sort((a, b) => b.confidence - a.confidence);
+  return { fixture_id: String(fixtureId), risk, legs };
+}

--- a/src/features/tips/seededRng.ts
+++ b/src/features/tips/seededRng.ts
@@ -1,0 +1,23 @@
+export function hashSeed(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    h = Math.imul(31, h) + seed.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+export function createRng(seed: string): () => number {
+  let a = hashSeed(seed);
+  return function mulberry32() {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function pickStable<T>(arr: T[], rng: () => number): T {
+  const idx = Math.floor(rng() * arr.length);
+  return arr[idx];
+}

--- a/src/lib/schemas/api.ts
+++ b/src/lib/schemas/api.ts
@@ -63,6 +63,35 @@ export const WeatherResponseSchema = z.object({
   source: z.literal('mock'),
 });
 
+export const TipsQuerySchema = z.object({
+  fixture_id: z.string().min(1),
+  risk: z.enum(['safe', 'balanced', 'spicy']).default('balanced').optional(),
+  exclude: z.string().optional(),
+  seed: z.string().optional(),
+});
+
+export const TipLegSchema = z.object({
+  market: z.enum([
+    'match_line',
+    'total_points',
+    'anytime_tryscorer',
+    'first_half_result',
+    'alt_total_points',
+    'first_tryscorer',
+  ]),
+  selection: z.string(),
+  price: z.number(),
+  confidence: z.number(),
+  rationale: z.string(),
+});
+
+export const TipsResponseSchema = z.object({
+  fixture_id: z.string(),
+  risk: z.enum(['safe', 'balanced', 'spicy']),
+  legs: z.array(TipLegSchema),
+});
+
 export type FixturesResponse = z.infer<typeof FixturesResponseSchema>;
 export type LineupsResponse = z.infer<typeof LineupsResponseSchema>;
 export type WeatherResponse = z.infer<typeof WeatherResponseSchema>;
+export type TipsResponse = z.infer<typeof TipsResponseSchema>;


### PR DESCRIPTION
## Summary
- add deterministic rule-based tip engine with seeded RNG and risk bands
- expose `/api/tips` endpoint with zod validation
- cover tip engine and API with unit tests
- document tip engine in build notes

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68992f48c56c832a80d953e81a878ced