### PR TITLE
feat(ui): add Match Hub pages (dashboard + match detail) with odds, lineups, weather panels

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -31,3 +31,10 @@
 - Added Next.js App Router layout with header, footer, and light/dark theme toggle.
 - Defined CSS design tokens using OKLCH variables for light and dark themes.
 - Introduced reusable Responsible Gambling banner that shows on bet-building routes.
+
+## Phase 7 notes
+- Added Match Hub with /dashboard round selector and fixture grid.
+- Introduced match detail pages showing odds, lineups, weather, quick insights, and Build My Bet CTA.
+- Odds snapshots sourced from local DB via latest snapshot helper; may be empty until CSV upload.
+- Weather is mocked via internal API; insights derived from weather and odds.
+- TODO: visualise odds movement and add richer insights.

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,15 @@
+import Skeleton from '../../components/ui/Skeleton';
+
+export default function Loading() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="border rounded p-4 space-y-2">
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-3 w-1/3" />
+          <Skeleton className="h-3 w-1/4" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,41 @@
-export default function DashboardPage() {
-  return <div>Dashboard coming soon.</div>;
+import FixtureList from '../../components/fixtures/FixtureList';
+import type { FixturesResponse } from '../../lib/schemas/api';
+
+interface DashboardPageProps {
+  searchParams: { round?: string };
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const round = Number(searchParams.round ?? 1);
+  const url = `${process.env.NEXT_PUBLIC_APP_URL ?? ''}/api/fixtures?round=${round}`;
+  let fixtures: FixturesResponse['fixtures'] = [];
+  let error: string | null = null;
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed');
+    const data: FixturesResponse = await res.json();
+    fixtures = data.fixtures;
+  } catch {
+    error = 'Failed to load fixtures.';
+  }
+  return (
+    <div className="space-y-4">
+      <form>
+        <label htmlFor="round" className="mr-2">
+          Round:
+        </label>
+        <select id="round" name="round" defaultValue={round} className="border p-1">
+          {[1, 2, 3, 4, 5].map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <button type="submit" className="ml-2 px-2 py-1 border rounded">
+          Go
+        </button>
+      </form>
+      {error ? <p>{error}</p> : <FixtureList fixtures={fixtures} />}
+    </div>
+  );
 }

--- a/src/app/match/[fixtureId]/loading.tsx
+++ b/src/app/match/[fixtureId]/loading.tsx
@@ -1,0 +1,13 @@
+import Skeleton from '../../../components/ui/Skeleton';
+
+export default function Loading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-6 w-1/3" />
+      <Skeleton className="h-4 w-1/2" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  );
+}

--- a/src/app/match/[fixtureId]/page.tsx
+++ b/src/app/match/[fixtureId]/page.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link';
+import OddsWidget from '../../../components/match/OddsWidget';
+import LineupsWidget from '../../../components/match/LineupsWidget';
+import WeatherWidget from '../../../components/match/WeatherWidget';
+import { getFixtureById } from '../../../lib/repos/fixtures';
+import { getLatestOddsSnapshot } from '../../../lib/repos/odds';
+import type { LineupsResponse, WeatherResponse } from '../../../lib/schemas/api';
+
+interface MatchPageProps {
+  params: { fixtureId: string };
+}
+
+export default async function MatchPage({ params }: MatchPageProps) {
+  const fixtureId = Number(params.fixtureId);
+  const fixture = await getFixtureById(fixtureId);
+  if (!fixture) return <div>Fixture not found.</div>;
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? '';
+
+  let lineups: LineupsResponse | null = null;
+  let lineupsError: string | null = null;
+  let weather: WeatherResponse | null = null;
+  let weatherError: string | null = null;
+  let odds: Awaited<ReturnType<typeof getLatestOddsSnapshot>> | null = null;
+  let oddsError: string | null = null;
+
+  try {
+    const res = await fetch(`${baseUrl}/api/lineups?fixture_id=${fixtureId}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('fail');
+    lineups = (await res.json()) as LineupsResponse;
+  } catch {
+    lineupsError = 'Unable to load lineups.';
+  }
+
+  try {
+    const res = await fetch(`${baseUrl}/api/weather?fixture_id=${fixtureId}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('fail');
+    weather = (await res.json()) as WeatherResponse;
+  } catch {
+    weatherError = 'Unable to load weather.';
+  }
+
+  try {
+    odds = await getLatestOddsSnapshot(fixtureId);
+  } catch {
+    oddsError = 'Unable to load odds.';
+  }
+
+  const insights: string[] = [];
+  if (odds && odds.homeWin != null && odds.awayWin != null) {
+    insights.push(odds.homeWin < odds.awayWin ? 'Home favourite' : 'Away favourite');
+  }
+  if (weather && weather.forecast.rain_chance > 50) insights.push('Rain likely');
+  if (weather && weather.forecast.wind_kph > 25) insights.push('Windy');
+  if (insights.length < 2) insights.push('Standard prep');
+  if (insights.length < 2) insights.push('No major factors');
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-bold">
+          {fixture.homeTeam.shortName} vs {fixture.awayTeam.shortName}
+        </h2>
+        <p className="text-sm text-gray-600">
+          {new Date(fixture.kickoffUtc).toLocaleString()} · {fixture.venue || 'TBD'}
+        </p>
+      </div>
+
+      <section>
+        <h3 className="font-medium mb-2">Odds snapshot</h3>
+        <OddsWidget odds={odds} error={oddsError} />
+      </section>
+
+      <section>
+        <h3 className="font-medium mb-2">Lineups</h3>
+        <LineupsWidget data={lineups} error={lineupsError} />
+      </section>
+
+      <section>
+        <h3 className="font-medium mb-2">Weather</h3>
+        <WeatherWidget data={weather} error={weatherError} />
+      </section>
+
+      <section>
+        <h3 className="font-medium mb-2">Quick insights</h3>
+        {insights.length ? (
+          <div className="flex flex-wrap gap-2">
+            {insights.map((i) => (
+              <span key={i} className="text-xs bg-gray-100 px-2 py-1 rounded">
+                {i}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p>No insights.</p>
+        )}
+      </section>
+
+      <div>
+        <Link
+          href={`/builder/${fixtureId}`}
+          className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Build My Bet
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fixtures/FixtureCard.tsx
+++ b/src/components/fixtures/FixtureCard.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Badge from '../ui/Badge';
+import { FixturesResponse } from '../../lib/schemas/api';
+
+export type Fixture = FixturesResponse['fixtures'][number];
+
+export default function FixtureCard({ fixture }: { fixture: Fixture }) {
+  const kickoff = new Date(fixture.kickoff_utc).toLocaleString();
+  return (
+    <Link
+      href={`/match/${fixture.id}`}
+      className="block border rounded p-4 hover:bg-gray-50"
+    >
+      <div className="font-medium">
+        {fixture.home_team.short_name} vs {fixture.away_team.short_name}
+      </div>
+      <div className="text-sm text-gray-600">{kickoff}</div>
+      <div className="text-sm text-gray-600">{fixture.venue || 'TBD'}</div>
+      {fixture.status && (
+        <div className="mt-2">
+          <Badge variant={fixture.status === 'scheduled' ? 'neutral' : 'success'}>
+            {fixture.status.toUpperCase()}
+          </Badge>
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/src/components/fixtures/FixtureList.tsx
+++ b/src/components/fixtures/FixtureList.tsx
@@ -1,0 +1,14 @@
+import FixtureCard, { Fixture } from './FixtureCard';
+
+export default function FixtureList({ fixtures }: { fixtures: Fixture[] }) {
+  if (!fixtures.length) {
+    return <p>No fixtures found for this round.</p>;
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {fixtures.map((f) => (
+        <FixtureCard key={f.id} fixture={f} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/match/LineupsWidget.tsx
+++ b/src/components/match/LineupsWidget.tsx
@@ -1,0 +1,29 @@
+import Badge from '../ui/Badge';
+import type { LineupsResponse } from '../../lib/schemas/api';
+
+export default function LineupsWidget({ data, error }: { data: LineupsResponse | null; error?: string | null }) {
+  if (error) return <p>{error}</p>;
+  if (!data) return <p>No lineups yet.</p>;
+  const confirmed = data.confirmed;
+  const renderNames = (names: unknown[]) =>
+    names.map((n, i) => <li key={i}>{typeof n === 'string' ? n : (n as any)?.name ?? 'TBD'}</li>);
+  return (
+    <div>
+      <div className="mb-2">
+        <Badge variant={confirmed ? 'success' : 'neutral'}>
+          {confirmed ? 'CONFIRMED' : 'UNCONFIRMED'}
+        </Badge>
+      </div>
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <h4 className="font-medium mb-1">Home</h4>
+          <ul className="list-disc pl-4">{renderNames(data.home.starters)}</ul>
+        </div>
+        <div>
+          <h4 className="font-medium mb-1">Away</h4>
+          <ul className="list-disc pl-4">{renderNames(data.away.starters)}</ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/match/OddsWidget.tsx
+++ b/src/components/match/OddsWidget.tsx
@@ -1,0 +1,25 @@
+interface OddsSnapshot {
+  capturedAt: Date;
+  homeWin?: number | null;
+  awayWin?: number | null;
+  line?: number | null;
+  total?: number | null;
+}
+
+export default function OddsWidget({ odds, error }: { odds: OddsSnapshot | null; error?: string | null }) {
+  if (error) return <p>{error}</p>;
+  if (!odds) return <p>No odds available.</p>;
+  return (
+    <div>
+      <p className="text-sm text-gray-600 mb-2">
+        As of {odds.capturedAt.toISOString()}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {odds.homeWin != null && <span className="px-2 py-1 border rounded">Home {odds.homeWin}</span>}
+        {odds.awayWin != null && <span className="px-2 py-1 border rounded">Away {odds.awayWin}</span>}
+        {odds.line != null && <span className="px-2 py-1 border rounded">Line {odds.line}</span>}
+        {odds.total != null && <span className="px-2 py-1 border rounded">Total {odds.total}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/match/WeatherWidget.tsx
+++ b/src/components/match/WeatherWidget.tsx
@@ -1,0 +1,15 @@
+import type { WeatherResponse } from '../../lib/schemas/api';
+
+export default function WeatherWidget({ data, error }: { data: WeatherResponse | null; error?: string | null }) {
+  if (error) return <p>{error}</p>;
+  if (!data) return <p>No weather data.</p>;
+  const f = data.forecast;
+  return (
+    <div className="text-sm space-y-1">
+      <p>Condition: {f.condition}</p>
+      <p>Temp: {f.temp_c}&deg;C</p>
+      <p>Wind: {f.wind_kph} kph</p>
+      <p>Rain chance: {f.rain_chance}%</p>
+    </div>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,13 @@
+interface BadgeProps {
+  children: React.ReactNode;
+  variant?: 'success' | 'neutral';
+}
+
+export default function Badge({ children, variant = 'neutral' }: BadgeProps) {
+  const base = 'px-2 py-0.5 text-xs rounded';
+  const color =
+    variant === 'success'
+      ? 'bg-green-100 text-green-800'
+      : 'bg-gray-100 text-gray-800';
+  return <span className={`${base} ${color}`}>{children}</span>;
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,3 @@
+export default function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse bg-gray-200 rounded ${className}`} />;
+}


### PR DESCRIPTION
## Summary
- build /dashboard with round selector fetching fixtures from internal API
- add match detail page showing odds, lineups, weather, and quick insights with Build My Bet CTA
- introduce reusable Badge and Skeleton plus widgets for odds, lineups, and weather panels
- document Match Hub data sources and future work

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6899357cce04832a92902cba7788a9f6