### PR TITLE
feat(ui): add Bet Builder with risk slider, exclusions and Copy Slip

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -43,3 +43,6 @@
 - Login and logout routes use Supabase in real envs and are bypassed in mock mode. Protected routes now include `/dashboard`, `/match/:id`, `/builder/:id`, `/my-bets`, and `/admin`.
 - Added a Settings page letting users set an optional nickname, favourite team, and risk profile.
 - Real auth requires `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `AUTH_MODE` env vars.
+## Phase 9 notes
+- Introduced Bet Builder page with risk slider, market exclusions, and suggestion list backed by `/api/tips`.
+- Users can copy a bookie-style slip using a new formatter utility.

--- a/src/app/builder/[fixtureId]/BetBuilderClient.tsx
+++ b/src/app/builder/[fixtureId]/BetBuilderClient.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import RiskSlider from '../../../components/builder/RiskSlider';
+import Exclusions from '../../../components/builder/Exclusions';
+import LegCard from '../../../components/builder/LegCard';
+import { Market, RiskBand } from '../../../features/tips/constants';
+import type { TipLeg } from '../../../features/tips/engine';
+import { formatSlip, copyToClipboard } from '../../../features/tips/format';
+import type { TipsResponse } from '../../../lib/schemas/api';
+
+interface Props {
+  fixtureId: string;
+}
+
+export default function BetBuilderClient({ fixtureId }: Props) {
+  const [risk, setRisk] = useState<RiskBand>(RiskBand.Balanced);
+  const [exclusions, setExclusions] = useState<Set<Market>>(new Set());
+  const [legs, setLegs] = useState<TipLeg[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const loadTips = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams({
+      fixture_id: fixtureId,
+      risk,
+    });
+    if (exclusions.size) {
+      params.set('exclude', Array.from(exclusions).join(','));
+    }
+    try {
+      const res = await fetch(`/api/tips?${params.toString()}`);
+      if (!res.ok) throw new Error('fail');
+      const data: TipsResponse = await res.json();
+      const typed = data.legs.map((l) => ({ ...l, market: l.market as Market })) as TipLeg[];
+      setLegs(typed);
+    } catch {
+      setError('Unable to load suggestions.');
+    } finally {
+      setLoading(false);
+    }
+  }, [fixtureId, risk, exclusions]);
+
+  useEffect(() => {
+    loadTips();
+  }, [loadTips]);
+
+  const handleCopy = async () => {
+    const text = formatSlip({ fixtureId, risk, legs });
+    const ok = await copyToClipboard(text);
+    setCopied(ok);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-bold mb-2">Bet Builder</h2>
+        <RiskSlider value={risk} onChange={setRisk} />
+      </div>
+
+      <section>
+        <h3 className="font-medium mb-2">Exclude markets</h3>
+        <Exclusions selected={exclusions} onChange={setExclusions} />
+      </section>
+
+      <section>
+        <h3 className="font-medium mb-2">Suggestions</h3>
+        {loading && <p>Loading...</p>}
+        {error && (
+          <div>
+            <p>{error}</p>
+            <button className="mt-2 px-2 py-1 border rounded" onClick={loadTips}>
+              Retry
+            </button>
+          </div>
+        )}
+        {!loading && !error && (
+          <div className="space-y-2">
+            {legs.map((leg, i) => (
+              <LegCard key={i} leg={leg} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <div>
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={handleCopy}
+          disabled={!legs.length}
+        >
+          Copy Slip
+        </button>
+        {copied && <span className="ml-2 text-sm">Copied!</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/app/builder/[fixtureId]/page.tsx
+++ b/src/app/builder/[fixtureId]/page.tsx
@@ -1,0 +1,9 @@
+import BetBuilderClient from './BetBuilderClient';
+
+interface BuilderPageProps {
+  params: { fixtureId: string };
+}
+
+export default function BuilderPage({ params }: BuilderPageProps) {
+  return <BetBuilderClient fixtureId={params.fixtureId} />;
+}

--- a/src/components/builder/Exclusions.tsx
+++ b/src/components/builder/Exclusions.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Market } from '../../features/tips/constants';
+import { MARKET_LABELS } from '../../features/tips/format';
+
+const ALL_MARKETS: Market[] = [
+  Market.AnytimeTryscorer,
+  Market.FirstHalfResult,
+  Market.MatchLine,
+  Market.TotalPoints,
+  Market.AltTotalPoints,
+  Market.FirstTryscorer,
+];
+
+interface Props {
+  selected: Set<Market>;
+  onChange: (s: Set<Market>) => void;
+}
+
+export default function Exclusions({ selected, onChange }: Props) {
+  const toggle = (m: Market) => {
+    const next = new Set(selected);
+    if (next.has(m)) next.delete(m);
+    else next.add(m);
+    onChange(next);
+  };
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ALL_MARKETS.map((m) => (
+        <label
+          key={m}
+          className={`px-2 py-1 border rounded text-sm cursor-pointer ${
+            selected.has(m) ? 'bg-gray-200' : ''
+          }`}
+        >
+          <input
+            type="checkbox"
+            className="hidden"
+            checked={selected.has(m)}
+            onChange={() => toggle(m)}
+          />
+          {MARKET_LABELS[m]}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/builder/LegCard.tsx
+++ b/src/components/builder/LegCard.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Badge from '../ui/Badge';
+import { MARKET_LABELS } from '../../features/tips/format';
+import type { TipLeg } from '../../features/tips/engine';
+
+export default function LegCard({ leg }: { leg: TipLeg }) {
+  const pct = Math.round(leg.confidence * 100);
+  return (
+    <div className="border rounded p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <Badge>{MARKET_LABELS[leg.market]}</Badge>
+        {leg.price != null && <span className="text-sm">@ {leg.price.toFixed(2)}</span>}
+      </div>
+      <div className="font-medium">{leg.selection}</div>
+      <div className="h-2 bg-gray-200 rounded">
+        <div className="h-2 bg-blue-500 rounded" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="text-xs text-gray-600">{pct}%</div>
+      <div>
+        <span className="text-xs bg-gray-100 px-2 py-1 rounded">{leg.rationale}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/builder/RiskSlider.tsx
+++ b/src/components/builder/RiskSlider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { RiskBand } from '../../features/tips/constants';
+
+interface Props {
+  value: RiskBand;
+  onChange: (r: RiskBand) => void;
+}
+
+const risks: RiskBand[] = [RiskBand.Safe, RiskBand.Balanced, RiskBand.Spicy];
+
+export default function RiskSlider({ value, onChange }: Props) {
+  const index = risks.indexOf(value);
+  return (
+    <div>
+      <input
+        type="range"
+        min={0}
+        max={2}
+        step={1}
+        value={index}
+        onChange={(e) => onChange(risks[Number(e.target.value)] as RiskBand)}
+        className="w-full"
+      />
+      <div className="flex justify-between text-xs mt-1">
+        <span>Safe</span>
+        <span>Balanced</span>
+        <span>Spicy</span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/tips/__tests__/format.test.ts
+++ b/src/features/tips/__tests__/format.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatSlip } from '../format';
+import { Market, RiskBand } from '../constants';
+import type { TipLeg } from '../engine';
+
+describe('formatSlip', () => {
+  it('formats a plain text slip', () => {
+    const legs: TipLeg[] = [
+      {
+        market: Market.AnytimeTryscorer,
+        selection: 'Player A',
+        price: 2.45,
+        confidence: 0.78,
+        rationale: 'Recent form + weak right edge',
+      },
+      {
+        market: Market.MatchLine,
+        selection: 'Home -6.5',
+        price: 1.9,
+        confidence: 0.74,
+        rationale: 'Home form + travel disadvantage',
+      },
+    ];
+    const text = formatSlip({ fixtureId: 123, risk: RiskBand.Balanced, legs });
+    expect(text).toBe(
+      [
+        'NRL — Fixture: 123',
+        'Risk: Balanced',
+        'Legs (2):',
+        '1) Anytime Tryscorer — Player A @ 2.45 (78%) — Recent form + weak right edge',
+        '2) Line — Home -6.5 @ 1.90 (74%) — Home form + travel disadvantage',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/features/tips/format.ts
+++ b/src/features/tips/format.ts
@@ -1,0 +1,62 @@
+import { RiskBand, Market } from './constants';
+import type { TipLeg } from './engine';
+
+export const MARKET_LABELS: Record<Market, string> = {
+  [Market.MatchLine]: 'Line',
+  [Market.TotalPoints]: 'Total Points',
+  [Market.AnytimeTryscorer]: 'Anytime Tryscorer',
+  [Market.FirstHalfResult]: 'First Half Result',
+  [Market.AltTotalPoints]: 'Alt Total',
+  [Market.FirstTryscorer]: 'First Tryscorer',
+};
+
+function cap(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+interface FormatArgs {
+  fixtureId: string | number;
+  risk: RiskBand;
+  legs: TipLeg[];
+}
+
+export function formatSlip({ fixtureId, risk, legs }: FormatArgs): string {
+  const lines = [
+    `NRL — Fixture: ${fixtureId}`,
+    `Risk: ${cap(risk)}`,
+    `Legs (${legs.length}):`,
+  ];
+  legs.forEach((leg, i) => {
+    const price = leg.price != null ? ` @ ${leg.price.toFixed(2)}` : '';
+    const conf = ` (${Math.round(leg.confidence * 100)}%)`;
+    lines.push(
+      `${i + 1}) ${MARKET_LABELS[leg.market]} — ${leg.selection}${price}${conf} — ${leg.rationale}`,
+    );
+  });
+  return lines.join('\n');
+}
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    const el = document.createElement('textarea');
+    el.value = text;
+    el.style.position = 'fixed';
+    el.style.left = '-9999px';
+    document.body.appendChild(el);
+    el.focus();
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- implement Bet Builder page to fetch tips, adjust risk/exclusions and copy a slip
- add formatter util and clipboard helper
- document builder controls and slip format

## Testing
- `pnpm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68993a48166c832aa68cdc2cb0a5afa7