### PR TITLE
feat(admin): add Admin Console with odds upload, ingest runs, and feature flags

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -53,3 +53,8 @@
 - Slips are saved via a server action from the Builder, stored against the signed-in user.
 - ROI formula: `(returnSum - stakeSum) / stakeSum` (pending slips ignored).
 - In CI, `getSession()` returns a mock user ensuring auth-dependent tests run offline.
+
+## Admin Console
+- Admin rights are checked via `assertAdmin()`. In tests or when `ADMIN_MODE=mock`, the `test-user` is treated as admin; otherwise a simple `ADMIN_USER_IDS` allowlist is used.
+- Odds CSVs are uploaded through a server action that validates a small file and parses rows with zod before upserting into `odds_snapshots`.
+- Feature flags live in the `FeatureFlag` table and can be toggled or given JSON payloads from the admin console.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,3 +1,175 @@
-export default function AdminPage() {
-  return <div>Admin tools coming soon.</div>;
+import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
+import type { ReactNode } from 'react';
+import { z } from 'zod';
+import assertAdmin from '../../lib/auth/admin';
+import uploadFromBuffer from '../../features/odds/uploadFromBuffer';
+import { listIngestRuns } from '../../lib/repos/ingest';
+import { listFlags, upsertFlag } from '../../lib/repos/flags';
+
+interface AdminPageProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+export default async function AdminPage({ searchParams }: AdminPageProps) {
+  await assertAdmin();
+  const tab = (typeof searchParams.tab === 'string' ? searchParams.tab : 'upload').toLowerCase();
+
+  async function uploadOdds(formData: FormData) {
+    'use server';
+    await assertAdmin();
+    const file = formData.get('file');
+    if (!(file instanceof File) || file.size === 0 || file.size > 200_000) {
+      redirect('/admin?tab=upload&error=Invalid+file');
+    }
+    try {
+      const buf = Buffer.from(await file.arrayBuffer());
+      const res = await uploadFromBuffer(buf);
+      redirect(`/admin?tab=upload&inserted=${res.inserted}&updated=${res.updated}&rows=${res.rows}`);
+    } catch (e: any) {
+      redirect(`/admin?tab=upload&error=${encodeURIComponent(e.message)}`);
+    }
+  }
+
+  async function refreshRuns() {
+    'use server';
+    await assertAdmin();
+    revalidatePath('/admin');
+  }
+
+  const flagSchema = z.object({
+    key: z.string().min(1),
+    enabled: z.coerce.boolean(),
+    payload: z
+      .string()
+      .optional()
+      .transform((v, ctx) => {
+        if (!v) return undefined;
+        try {
+          return JSON.parse(v);
+        } catch {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid JSON' });
+          return z.NEVER;
+        }
+      }),
+  });
+
+  async function saveFlag(formData: FormData) {
+    'use server';
+    await assertAdmin();
+    const values = flagSchema.parse({
+      key: formData.get('key'),
+      enabled: formData.get('enabled'),
+      payload: formData.get('payload'),
+    });
+    await upsertFlag({
+      key: values.key,
+      enabled: values.enabled,
+      payload_json: values.payload,
+    });
+    revalidatePath('/admin');
+  }
+
+  let content: ReactNode = null;
+  if (tab === 'ingest') {
+    const runs = await listIngestRuns(50);
+    content = (
+      <div>
+        <form action={refreshRuns}>
+          <button type="submit" className="border px-2 py-1 mb-2">Refresh</button>
+        </form>
+        <table className="border-collapse border">
+          <thead>
+            <tr>
+              <th className="border px-2">started_at</th>
+              <th className="border px-2">finished_at</th>
+              <th className="border px-2">type</th>
+              <th className="border px-2">status</th>
+              <th className="border px-2">error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((r: any) => (
+              <tr key={r.id}>
+                <td className="border px-2">{r.startedAt.toISOString()}</td>
+                <td className="border px-2">{r.finishedAt ? r.finishedAt.toISOString() : '-'}</td>
+                <td className="border px-2">{r.type}</td>
+                <td className="border px-2">{r.status}</td>
+                <td className="border px-2">{r.error ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  } else if (tab === 'flags') {
+    const flags = await listFlags();
+    content = (
+      <div className="space-y-4">
+        {flags.map((f: any) => (
+          <form key={f.key} action={saveFlag} className="border p-2">
+            <input type="hidden" name="key" value={f.key} />
+            <label className="block">
+              <input
+                type="checkbox"
+                name="enabled"
+                defaultChecked={f.enabled}
+                value="true"
+              />{' '}
+              {f.key}
+            </label>
+            <textarea
+              name="payload"
+              defaultValue={f.payloadJson ? JSON.stringify(f.payloadJson, null, 2) : ''}
+              className="border w-full mt-1"
+              rows={3}
+            />
+            <button type="submit" className="border px-2 py-1 mt-1">
+              Save
+            </button>
+          </form>
+        ))}
+        <form action={saveFlag} className="border p-2">
+          <input placeholder="key" name="key" className="border px-1" />
+          <label className="block">
+            <input type="checkbox" name="enabled" /> enabled
+          </label>
+          <textarea name="payload" className="border w-full mt-1" rows={3} />
+          <button type="submit" className="border px-2 py-1 mt-1">
+            Add
+          </button>
+        </form>
+      </div>
+    );
+  } else {
+    const inserted = searchParams.inserted;
+    const updated = searchParams.updated;
+    const rows = searchParams.rows;
+    const error = searchParams.error;
+    content = (
+      <div>
+        {error && <p className="text-red-600">{error}</p>}
+        {inserted && (
+          <p>
+            Uploaded {rows} rows (inserted {inserted}, updated {updated}).
+          </p>
+        )}
+        <form action={uploadOdds}>
+          <input type="file" name="file" accept=".csv" className="block mb-2" />
+          <button type="submit" className="border px-2 py-1">Upload</button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <nav className="space-x-4">
+        <a href="/admin?tab=upload">Odds Upload</a>
+        <a href="/admin?tab=ingest">Ingestion Runs</a>
+        <a href="/admin?tab=flags">Feature Flags</a>
+      </nav>
+      {content}
+    </div>
+  );
 }

--- a/src/app/api/odds/upload/route.ts
+++ b/src/app/api/odds/upload/route.ts
@@ -1,6 +1,4 @@
-import { parseCsv } from '../../../../lib/csv';
-import { prisma } from '../../../../lib/db';
-import { zOddsRow, type OddsRow } from '../../../../lib/schemas/odds';
+import uploadFromBuffer from '../../../../features/odds/uploadFromBuffer';
 
 export async function POST(req: Request): Promise<Response> {
   if (req.headers.get('x-demo-admin') !== '1') {
@@ -17,41 +15,11 @@ export async function POST(req: Request): Promise<Response> {
   if (!(file instanceof File)) {
     return new Response('Missing file', { status: 400 });
   }
-  const text = await file.text();
-  const records = parseCsv(text);
-  const valid: OddsRow[] = [];
-  const errors: { row: number; message: string }[] = [];
-  records.forEach((record, idx) => {
-    const res = zOddsRow.safeParse(record);
-    if (res.success) {
-      valid.push(res.data);
-    } else {
-      errors.push({ row: idx + 2, message: res.error.issues[0].message });
-    }
-  });
-  if (errors.length) {
-    const msg = errors
-      .slice(0, 3)
-      .map((e) => `Row ${e.row}: ${e.message}`)
-      .join('; ');
-    return new Response(msg, { status: 400 });
+  try {
+    const buf = Buffer.from(await file.arrayBuffer());
+    const result = await uploadFromBuffer(buf);
+    return Response.json(result);
+  } catch (err: any) {
+    return new Response(err.message || 'Invalid CSV', { status: 400 });
   }
-  let inserted = 0;
-  let updated = 0;
-  for (const row of valid) {
-    const existing = await prisma.oddsSnapshot.findFirst({
-      where: { fixtureId: row.fixtureId, capturedAt: row.capturedAt },
-    });
-    if (existing) {
-      await prisma.oddsSnapshot.update({
-        where: { id: existing.id },
-        data: row,
-      });
-      updated += 1;
-    } else {
-      await prisma.oddsSnapshot.create({ data: row });
-      inserted += 1;
-    }
-  }
-  return Response.json({ inserted, updated, rows: valid.length });
 }

--- a/src/features/odds/uploadFromBuffer.ts
+++ b/src/features/odds/uploadFromBuffer.ts
@@ -1,0 +1,49 @@
+import { parseCsv } from '../../lib/csv';
+import { prisma } from '../../lib/db';
+import { zOddsRow, type OddsRow } from '../../lib/schemas/odds';
+
+/**
+ * Parse an odds CSV buffer and upsert snapshots.
+ * Returns counts of inserted and updated rows.
+ */
+export async function uploadFromBuffer(buf: Buffer) {
+  const text = buf.toString('utf8');
+  const records = parseCsv(text);
+  const valid: OddsRow[] = [];
+  const errors: { row: number; message: string }[] = [];
+  records.forEach((record, idx) => {
+    const res = zOddsRow.safeParse(record);
+    if (res.success) {
+      valid.push(res.data);
+    } else {
+      errors.push({ row: idx + 2, message: res.error.issues[0].message });
+    }
+  });
+  if (errors.length) {
+    const msg = errors
+      .slice(0, 3)
+      .map((e) => `Row ${e.row}: ${e.message}`)
+      .join('; ');
+    throw new Error(msg);
+  }
+  let inserted = 0;
+  let updated = 0;
+  for (const row of valid) {
+    const existing = await prisma.oddsSnapshot.findFirst({
+      where: { fixtureId: row.fixtureId, capturedAt: row.capturedAt },
+    });
+    if (existing) {
+      await prisma.oddsSnapshot.update({
+        where: { id: existing.id },
+        data: row,
+      });
+      updated += 1;
+    } else {
+      await prisma.oddsSnapshot.create({ data: row });
+      inserted += 1;
+    }
+  }
+  return { inserted, updated, rows: valid.length };
+}
+
+export default uploadFromBuffer;

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -1,0 +1,17 @@
+import { getSession } from './session';
+
+/**
+ * Ensures the current user is an admin.
+ */
+export async function assertAdmin() {
+  const { userId } = await getSession();
+  if (!userId) throw new Error('Forbidden');
+  if (process.env.ADMIN_MODE === 'mock' || process.env.NODE_ENV === 'test') {
+    if (userId === 'test-user') return;
+  }
+  const allow = process.env.ADMIN_USER_IDS?.split(',').map((s) => s.trim());
+  if (allow?.includes(userId)) return;
+  throw new Error('Forbidden');
+}
+
+export default assertAdmin;

--- a/src/lib/repos/flags.ts
+++ b/src/lib/repos/flags.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { prisma } from '../db';
+
+export async function listFlags() {
+  return prisma.featureFlag.findMany({ orderBy: { key: 'asc' } });
+}
+
+const upsertSchema = z.object({
+  key: z.string().min(1),
+  enabled: z.boolean(),
+  payload_json: z.any().optional(),
+});
+
+export async function upsertFlag(input: unknown) {
+  const data = upsertSchema.parse(input);
+  return prisma.featureFlag.upsert({
+    where: { key: data.key },
+    update: { enabled: data.enabled, payloadJson: data.payload_json },
+    create: { key: data.key, enabled: data.enabled, payloadJson: data.payload_json },
+  });
+}

--- a/tests/flags.repo.test.ts
+++ b/tests/flags.repo.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@prisma/client';
+import { PrismaClient as MockClient } from './prismaMock';
+
+vi.mock('@prisma/client', () => ({ PrismaClient: MockClient }));
+
+let prisma: PrismaClient;
+let listFlags: () => Promise<any[]>;
+let upsertFlag: (input: { key: string; enabled: boolean; payload_json?: any }) => Promise<any>;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../src/lib/db'));
+  ({ listFlags, upsertFlag } = await import('../src/lib/repos/flags'));
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('feature flags repo', () => {
+  it('creates and updates flags', async () => {
+    await upsertFlag({ key: 'test', enabled: false });
+    let flags = await listFlags();
+    expect(flags.find((f) => f.key === 'test')?.enabled).toBe(false);
+    await upsertFlag({ key: 'test', enabled: true, payload_json: { foo: 'bar' } });
+    flags = await listFlags();
+    const flag = flags.find((f) => f.key === 'test');
+    expect(flag?.enabled).toBe(true);
+    expect(flag?.payloadJson).toEqual({ foo: 'bar' });
+  });
+});

--- a/tests/prismaMock.ts
+++ b/tests/prismaMock.ts
@@ -5,6 +5,7 @@ export const db = {
   lineups: [] as any[],
   oddsSnapshots: [] as any[],
   ingestRuns: [] as any[],
+  featureFlags: [] as any[],
   users: [] as any[],
   profiles: [] as any[],
   betSlips: [] as any[],
@@ -144,6 +145,19 @@ export class PrismaClient {
         .slice()
         .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())
         .slice(0, take);
+    },
+  };
+  featureFlag = {
+    findMany: async () => db.featureFlags.slice(),
+    upsert: async ({ where, update, create }: any) => {
+      let f = db.featureFlags.find((fl) => fl.key === where.key);
+      if (f) {
+        Object.assign(f, update);
+      } else {
+        f = { id: db.featureFlags.length + 1, ...create };
+        db.featureFlags.push(f);
+      }
+      return f;
     },
   };
   betSlip = {

--- a/tests/uploadFromBuffer.test.ts
+++ b/tests/uploadFromBuffer.test.ts
@@ -1,0 +1,28 @@
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@prisma/client';
+import { PrismaClient as MockClient } from './prismaMock';
+
+vi.mock('@prisma/client', () => ({ PrismaClient: MockClient }));
+
+let prisma: PrismaClient;
+let uploadFromBuffer: (buf: Buffer) => Promise<{ inserted: number; updated: number; rows: number }>;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../src/lib/db'));
+  ({ uploadFromBuffer } = await import('../src/features/odds/uploadFromBuffer'));
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('uploadFromBuffer', () => {
+  it('inserts and updates odds snapshots', async () => {
+    const csv = 'fixture_id,captured_at,home_win,away_win\n1,2025-01-01T00:00:00Z,1.1,4.2';
+    const res1 = await uploadFromBuffer(Buffer.from(csv));
+    expect(res1).toEqual({ inserted: 1, updated: 0, rows: 1 });
+    const res2 = await uploadFromBuffer(Buffer.from(csv));
+    expect(res2.inserted).toBe(0);
+    expect(res2.updated).toBe(1);
+  });
+});

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -6,6 +6,7 @@ declare module '@prisma/client' {
     lineup: any;
     oddsSnapshot: any;
     ingestRun: any;
+    featureFlag: any;
     user: any;
     profile: any;
     betSlip: any;


### PR DESCRIPTION
## Summary
- add admin console with odds upload, ingest runs view, and feature flag management
- secure admin routes with assertAdmin allowlist
- refactor odds upload CSV parsing into uploadFromBuffer helper
- add minimal tests for flags repo and odds upload helper

## Testing
- `pnpm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68994052118c832a9d8709625429a01e