### PR TITLE
feat: add legal pages and RG banner tests

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -58,3 +58,8 @@
 - Admin rights are checked via `assertAdmin()`. In tests or when `ADMIN_MODE=mock`, the `test-user` is treated as admin; otherwise a simple `ADMIN_USER_IDS` allowlist is used.
 - Odds CSVs are uploaded through a server action that validates a small file and parses rows with zod before upserting into `odds_snapshots`.
 - Feature flags live in the `FeatureFlag` table and can be toggled or given JSON payloads from the admin console.
+
+## Legal & RG notes
+- Added concise Terms, Privacy summary, and Responsible Gambling guidance pages plus footer links.
+- RG banner now highlights 18+ usage and information-only disclaimers.
+- Copy is non-binding and pending counsel review and helpline verification.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,14 @@ function Footer() {
     <footer className="p-4 border-t text-sm text-center">
       <p>
         &copy; {new Date().getFullYear()} Beat the Bet ·{' '}
+        <Link href="/legal/terms" className="underline">
+          Terms
+        </Link>{' '}·{' '}
+        <Link href="/legal/privacy" className="underline">
+          Privacy
+        </Link>{' '}·{' '}
         <Link href="/legal/responsible-gambling" className="underline">
-          Gamble responsibly
+          Responsible Gambling
         </Link>
       </p>
     </footer>

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -1,3 +1,31 @@
 export default function PrivacyPage() {
-  return <div>Privacy Policy placeholder.</div>;
+  return (
+    <main className="prose">
+      <h1>Privacy Summary</h1>
+      <p>This overview is informational and not legal advice.</p>
+      <h2>Data We Collect</h2>
+      <ul>
+        <li>Account details and profile preferences.</li>
+        <li>App telemetry such as copy slip events.</li>
+        <li>Minimal logs for reliability.</li>
+      </ul>
+      <h2>Why We Collect It</h2>
+      <ul>
+        <li>To personalise suggestions and user experience.</li>
+        <li>To improve product reliability and UX.</li>
+      </ul>
+      <h2>Retention</h2>
+      <ul>
+        <li>Profile data remains until you delete your account.</li>
+        <li>Telemetry is aggregated.</li>
+        <li>Logs are rotated regularly.</li>
+      </ul>
+      <h2>Your Rights</h2>
+      <p>You may request an export or deletion of your data by emailing <a href="mailto:support@example.com">support@example.com</a>.</p>
+      <h2>Security</h2>
+      <p>Server-side secrets, row level security, and admin audit logs help protect your data.</p>
+      <h2>Contact</h2>
+      <p>Email <a href="mailto:support@example.com">support@example.com</a> with privacy questions.</p>
+    </main>
+  );
 }

--- a/src/app/legal/responsible-gambling/page.tsx
+++ b/src/app/legal/responsible-gambling/page.tsx
@@ -1,3 +1,25 @@
 export default function ResponsibleGamblingPage() {
-  return <div>Responsible Gambling information placeholder.</div>;
+  return (
+    <main className="prose">
+      <h1>Responsible Gambling</h1>
+      <p>This guidance is informational and not legal advice.</p>
+      <h2>Set Limits</h2>
+      <ul>
+        <li>Decide a budget before you bet and stick to it.</li>
+        <li>Only gamble what you can afford to lose.</li>
+      </ul>
+      <h2>Take Breaks</h2>
+      <ul>
+        <li>Avoid chasing losses.</li>
+        <li>Step away if betting stops being fun.</li>
+      </ul>
+      <h2>Self-exclusion and Support</h2>
+      <p>If gambling is causing harm, consider self-exclusion and seek help.</p>
+      <ul>
+        <li><a href="#">[Your state helpline]</a></li>
+        <li><a href="#">[Self-exclusion program]</a></li>
+      </ul>
+      <p>Our suggestions are informational only and cannot guarantee results. You must be 18+ to use this service.</p>
+    </main>
+  );
 }

--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -1,3 +1,28 @@
 export default function TermsPage() {
-  return <div>Terms and Conditions placeholder.</div>;
+  return (
+    <main className="prose">
+      <h1>Terms of Use</h1>
+      <p>This summary is for information only and is not legal advice.</p>
+      <h2>About the Service</h2>
+      <p>Beat the Bet provides betting insights. We are not a bookmaker and do not handle wagers or payments.</p>
+      <h2>Use at Your Own Risk</h2>
+      <p>No outcomes or profits are guaranteed. Use any suggestions at your own risk.</p>
+      <h2>Eligibility</h2>
+      <p>You must be 18+ and follow local laws to use the service.</p>
+      <h2>Prohibited Uses</h2>
+      <ul>
+        <li>Scraping or reverse engineering our content.</li>
+        <li>Automating access without permission.</li>
+      </ul>
+      <h2>Liability</h2>
+      <p>The service is provided “as is” without warranties. We are not liable for indirect losses.</p>
+      <h2>Changes</h2>
+      <p>
+        We may update these terms at any time. Continued use means acceptance. Contact
+        {' '}
+        <a href="mailto:support@example.com">support@example.com</a>{' '}
+        with questions or disputes.
+      </p>
+    </main>
+  );
 }

--- a/src/components/RGBanner.tsx
+++ b/src/components/RGBanner.tsx
@@ -8,7 +8,7 @@ export default function RGBanner() {
   return (
     <div className="bg-[var(--color-warning)] text-black px-4 py-2 text-sm flex justify-between" role="region" aria-label="responsible gambling">
       <span>
-        Gamble responsibly.{' '}
+        18+ only. Information only, no guarantees. Gamble responsibly.{` `}
         <Link href="/legal/responsible-gambling" className="underline">
           Learn more
         </Link>

--- a/tests/rg.routes.test.ts
+++ b/tests/rg.routes.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowRGBanner } from '../src/lib/rg';
+
+describe('shouldShowRGBanner', () => {
+  it('returns true for bet-related routes', () => {
+    ['/builder/123', '/match/abc', '/my-bets'].forEach((path) => {
+      expect(shouldShowRGBanner(path)).toBe(true);
+    });
+  });
+
+  it('returns false for non-bet routes', () => {
+    ['/', '/admin', '/login', '/settings', '/legal/terms'].forEach((path) => {
+      expect(shouldShowRGBanner(path)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Terms of Use, Privacy summary, and Responsible Gambling pages and link them in the footer
- strengthen Responsible Gambling banner messaging with 18+ info-only disclaimer
- test banner visibility policy for bet-related routes
- document legal & RG notes for future counsel review

## Testing
- `pnpm run ci`

------
https://chatgpt.com/codex/tasks/task_e_689942dc75f4832a8eb1ef40351fcd18