### PR TITLE
Add server-side analytics pipeline

### DIFF
--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -54,6 +54,11 @@
 - ROI formula: `(returnSum - stakeSum) / stakeSum` (pending slips ignored).
 - In CI, `getSession()` returns a mock user ensuring auth-dependent tests run offline.
 
+## Analytics
+- Added server-side `Event` table logging `builder_open`, `copy_slip`, and `save_slip` events.
+- Bet Builder triggers these events via a server action.
+- `propsJson` stores small payloads without PII; `userId` is optional.
+
 ## Admin Console
 - Admin rights are checked via `assertAdmin()`. In tests or when `ADMIN_MODE=mock`, the `test-user` is treated as admin; otherwise a simple `ADMIN_USER_IDS` allowlist is used.
 - Odds CSVs are uploaded through a server action that validates a small file and parses rows with zod before upserting into `odds_snapshots`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -165,3 +165,14 @@ model AuditLog {
   at     DateTime @default(now())
 }
 
+model Event {
+  id        String   @id @default(cuid())
+  userId    String?
+  event     String
+  propsJson Json
+  createdAt DateTime @default(now())
+
+  @@index([event, createdAt])
+  @@index([userId, createdAt])
+}
+

--- a/src/app/actions/analytics.ts
+++ b/src/app/actions/analytics.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { z } from 'zod';
+import { serverLog } from '../../lib/analytics';
+
+const schema = z.object({
+  event: z.string().min(1),
+  props: z.record(z.string(), z.unknown()).optional(),
+});
+
+/**
+ * Server action wrapper for logging analytics events.
+ */
+export async function logEventAction(formDataOrObj: FormData | { event: string; props?: Record<string, unknown> }) {
+  const obj =
+    formDataOrObj instanceof FormData
+      ? {
+          event: formDataOrObj.get('event'),
+          props: formDataOrObj.get('props')
+            ? JSON.parse(formDataOrObj.get('props') as string)
+            : undefined,
+        }
+      : formDataOrObj;
+  const { event, props } = schema.parse(obj);
+  await serverLog(event, props);
+}

--- a/src/app/builder/[fixtureId]/BetBuilderClient.tsx
+++ b/src/app/builder/[fixtureId]/BetBuilderClient.tsx
@@ -9,6 +9,7 @@ import type { TipLeg } from '../../../features/tips/engine';
 import { formatSlip, copyToClipboard } from '../../../features/tips/format';
 import type { TipsResponse } from '../../../lib/schemas/api';
 import { saveSlipAction } from '../../my-bets/actions';
+import { logEvent } from '../../../lib/clientAnalytics';
 import Link from 'next/link';
 
 interface Props {
@@ -52,10 +53,15 @@ export default function BetBuilderClient({ fixtureId }: Props) {
     loadTips();
   }, [loadTips]);
 
+  useEffect(() => {
+    logEvent('builder_open', { fixtureId, risk });
+  }, [fixtureId]);
+
   const handleCopy = async () => {
     const text = formatSlip({ fixtureId, risk, legs });
     const ok = await copyToClipboard(text);
     setCopied(ok);
+    if (ok) logEvent('copy_slip', { fixtureId, risk, legsCount: legs.length });
     setTimeout(() => setCopied(false), 2000);
   };
 
@@ -68,6 +74,7 @@ export default function BetBuilderClient({ fixtureId }: Props) {
       try {
         await saveSlipAction(formData);
         setSaved(true);
+        logEvent('save_slip', { fixtureId, risk, legsCount: legs.length });
       } catch {
         setError('Unable to save slip.');
       }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,12 @@
+import { logEvent } from './repos/events';
+import { getSession } from './auth/session';
+
+/**
+ * Log an analytics event for the current session user.
+ */
+export async function serverLog(event: string, props?: Record<string, unknown>) {
+  const { userId } = await getSession();
+  await logEvent({ userId, event, props });
+}
+
+export default serverLog;

--- a/src/lib/clientAnalytics.ts
+++ b/src/lib/clientAnalytics.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { logEventAction } from '../app/actions/analytics';
+
+/**
+ * Send a client-side analytics event via server action.
+ */
+export function logEvent(event: string, props?: Record<string, unknown>) {
+  return logEventAction({ event, props });
+}

--- a/src/lib/repos/events.ts
+++ b/src/lib/repos/events.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { prisma } from '../db';
+
+const logSchema = z.object({
+  userId: z.string().optional().nullable(),
+  event: z.string().min(1),
+  props: z.record(z.string(), z.unknown()).optional(),
+});
+
+const listSchema = z.object({
+  userId: z.string().optional().nullable(),
+  limit: z.number().int().min(1).max(100).default(50),
+});
+
+/**
+ * Persist a simple analytics event.
+ */
+export async function logEvent({
+  userId,
+  event,
+  props,
+}: {
+  userId?: string | null;
+  event: string;
+  props?: Record<string, unknown>;
+}) {
+  const data = logSchema.parse({ userId, event, props });
+  await prisma.event.create({
+    data: {
+      userId: data.userId ?? null,
+      event: data.event,
+      propsJson: data.props ?? {},
+    },
+  });
+}
+
+/**
+ * Fetch recent events optionally filtered by user.
+ */
+export async function getRecentEvents({
+  userId,
+  limit = 50,
+}: {
+  userId?: string | null;
+  limit?: number;
+} = {}) {
+  const params = listSchema.parse({ userId, limit });
+  return prisma.event.findMany({
+    where: params.userId ? { userId: params.userId } : undefined,
+    orderBy: { createdAt: 'desc' },
+    take: params.limit,
+  });
+}
+
+export default logEvent;

--- a/tests/events.repo.test.ts
+++ b/tests/events.repo.test.ts
@@ -1,0 +1,37 @@
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@prisma/client';
+import { PrismaClient as MockClient } from './prismaMock';
+
+vi.mock('@prisma/client', () => ({ PrismaClient: MockClient }));
+
+let prisma: PrismaClient;
+let logEvent: typeof import('../src/lib/repos/events').logEvent;
+let getRecentEvents: typeof import('../src/lib/repos/events').getRecentEvents;
+
+beforeAll(async () => {
+  ({ prisma } = await import('../src/lib/db'));
+  ({ logEvent, getRecentEvents } = await import('../src/lib/repos/events'));
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('events repo', () => {
+  it('logs and queries events', async () => {
+    await logEvent({ userId: 'u1', event: 'builder_open', props: { fixtureId: 1, risk: 'safe' } });
+    await logEvent({ userId: null, event: 'copy_slip', props: { fixtureId: 1, risk: 'safe', legsCount: 2 } });
+
+    const recent = await getRecentEvents();
+    expect(recent.length).toBe(2);
+    const events = recent.map((e: any) => e.event);
+    expect(events).toContain('builder_open');
+    expect(events).toContain('copy_slip');
+    const builder = recent.find((e: any) => e.event === 'builder_open');
+    expect(builder?.propsJson).toEqual({ fixtureId: 1, risk: 'safe' });
+
+    const userEvents = await getRecentEvents({ userId: 'u1' });
+    expect(userEvents.length).toBe(1);
+    expect(userEvents[0].event).toBe('builder_open');
+  });
+});

--- a/tests/prismaMock.ts
+++ b/tests/prismaMock.ts
@@ -10,6 +10,7 @@ export const db = {
   profiles: [] as any[],
   betSlips: [] as any[],
   betOutcomes: [] as any[],
+  events: [] as any[],
 };
 
 let oddsId = 1;
@@ -208,6 +209,24 @@ export class PrismaClient {
       if (!o) return null;
       Object.assign(o, data);
       return o;
+    },
+  };
+  event = {
+    create: async ({ data }: any) => {
+      const obj = { id: String(db.events.length + 1), createdAt: new Date(), ...data };
+      db.events.push(obj);
+      return obj;
+    },
+    findMany: async ({ where, orderBy, take }: any) => {
+      let res = db.events.slice();
+      if (where?.userId) {
+        res = res.filter((e) => e.userId === where.userId);
+      }
+      if (orderBy?.createdAt === 'desc') {
+        res = res.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      }
+      if (take) res = res.slice(0, take);
+      return res;
     },
   };
   $disconnect = async () => {};

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -11,6 +11,7 @@ declare module '@prisma/client' {
     profile: any;
     betSlip: any;
     betOutcome: any;
+    event: any;
     $disconnect(): Promise<void>;
   }
 }


### PR DESCRIPTION
## Summary
- add `Event` model and helpers for logging analytics
- log builder_open, copy_slip, and save_slip events in Bet Builder
- document analytics pipeline and privacy stance

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm run ci`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm prisma generate` *(fails: Failed to fetch the engine file at ... 403 Forbidden)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm prisma db push` *(fails: Failed to fetch the engine file at ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689944603458832ab3a133da3e3ffa6d